### PR TITLE
Set Terraform variables defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,32 @@
 # Blueprint: Preparing a GKE cluster for apps distributed by a third party
 
-This repository contains a blueprint that creates and secures a [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/concepts/kubernetes-engine-overview) (GKE) cluster that is ready to host custom apps distributed by a third party.
-For more information about the architecture of this blueprint, refer to [Preparing a GKE cluster for third-party tenants](https://cloud.google.com/architecture/preparing-gke-cluster-apps-distributed-third-party).
+This repository contains a blueprint that creates and secures a
+[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/concepts/kubernetes-engine-overview)
+(GKE) cluster that is ready to host custom apps distributed by a third party.
+For more information about the architecture of this blueprint, refer to
+[Preparing a GKE cluster for third-party tenants](https://cloud.google.com/architecture/preparing-gke-cluster-apps-distributed-third-party).
 
-This blueprint suggests using a GKE cluster as the compute infrastructure to host containerized apps distributed by a third party.
-These apps are considered as untrusuted or semi-trusted workloads within the cluster. Therefore, the cluster is configured according to security best practices, and additional controls are put
-in place to isolate and constrain the workloads. The blueprint uses [Anthos](https://cloud.google.com/anthos) features to automate and optimise the configuration and security of the cluster.
+This blueprint uses a GKE cluster as the compute infrastructure to host
+containerized apps distributed by a third party. These apps are considered as
+untrusuted or semi-trusted workloads within the cluster. Therefore, the cluster
+is configured according to security best practices to isolate and constrain the
+workloads from other workloads and from the cluster control plane. The blueprint
+uses [Anthos](https://cloud.google.com/anthos) features to automate and optimise
+the configuration and security of the cluster.
 
 This blueprint provisions cloud resources on Google Cloud. After the initial provisioning,
-you can extended the infrastructure to Anthos clusters running on premises
-or on other public clouds.
+you can extended the infrastructure to [Anthos clusters running on premises or on other public clouds](https://cloud.google.com/anthos/clusters/docs/multi-cloud).
 
 ## Getting started
 
 To deploy this blueprint you need:
 
 - A [Google Cloud project](https://cloud.google.com/docs/overview#projects) with billing enabled
-- Owner permissions on the project
+- An account with the [Project Owner role](https://cloud.google.com/iam/docs/understanding-roles#resource-manager-roles) on the project
 
 You create the infastructure using Terraform. The blueprint uses a local [Terraform backend](https://www.terraform.io/docs/language/settings/backends/configuration.html),
-but we recommend to configure a remote backend for anything other than experimentation.
+but we recommend to configure a [remote backend](https://www.terraform.io/language/settings/backends/configuration#backend-types)
+for anything other than experimentation.
 
 ## Understanding the repository structure
 
@@ -116,42 +123,53 @@ The blueprint configures a dedicated namespace for tenant apps and resources:
 
 - Open [Cloud Shell](https://cloud.google.com/shell)
 - Clone this repository
-- Change into the directory that contains the Terraform code
+- Change into the directory that contains the Terraform code:
 
-  ```cd [REPO]/terraform```
+  ```sh
+  cd [REPO]/terraform
+  ```
 
-- Set a Terraform environment variable for your project ID
+  Where `[REPO]` is the path to the directory where you cloned this repository.
+
+- Set a Terraform environment variable for your project ID:
 
   ```sh
   TF_VAR_project_id=[YOUR_PROJECT_ID]
   export TF_VAR_project_id
   ```
 
-- Initialize Terraform
+- Initialize Terraform:
 
-  ```terraform init```
+  ```sh
+  terraform init
+  ```
 
-- Create the plan; review it so you know what's going on
+- Create the plan and review it:
 
-  ```terraform plan -out terraform.out```
+  ```sh
+  terraform plan -out terraform.out
+  ```
 
-- Apply the plan to create the cluster. Note this may take ~15 minutes to complete
+- Apply the plan to create the cluster:
 
-  ```terraform apply terraform.out```
+  ```sh
+  terraform apply terraform.out
+  ```
+
+   Note: this may take ~15 minutes to complete
 
 ## Test
 
-See [testing](testing) for some manual tests you can perform to verify setup
+For more details about manual tests you can perform to validate this setup,
+refer to the [testing directory](testing).
 
 ## Add another tenant
 
-Out-of-the-box the blueprint is configured with a single tenant called 'fltenant1'.
+This blueprint provisions a runtime environment for a single tenant.
 
-Adding another tenant is a two-stage process:
+To add another tenant, you:
 
-1. Create the project-level infra and resources for the tenant (node pool, service accounts, firewall rules...).
-You do this by updating the Terraform config and re-applying.
-1. Configure cluster-level resources for the tenant (namespace, network policies, service mesh policies...)
-You do this by instantiating and configuring a new version of the tenant kpt package, and then applying to the cluster.
+1. Create the project-level infrastructure and resources for the new tenant by updating the Terraform descriptors.
+1. Configure cluster-level resources for the new tenant by instantiating and configuring a new version of the `tenant` kpt package.
 
-See the relevant section in [testing](testing) for instructions.
+For an example of this process, refer to the [testing directory](testing).

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The blueprint configures a dedicated namespace for tenant apps and resources:
   terraform apply terraform.out
   ```
 
-   Note: this may take ~15 minutes to complete
+  Note: this may take ~15 minutes to complete
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -131,13 +131,7 @@ The blueprint configures a dedicated namespace for tenant apps and resources:
 
   Where `[REPO]` is the path to the directory where you cloned this repository.
 
-- Set a Terraform environment variable for your project ID:
-
-  ```sh
-  TF_VAR_project_id=[YOUR_PROJECT_ID]
-  export TF_VAR_project_id
-  ```
-
+- Set a Terraform environment variable for your project ID in the `terraform.tfvars` file by setting the value of the `project_id` variable.
 - Initialize Terraform:
 
   ```sh

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,20 +1,2 @@
-# GKE cluster name
-cluster_name = "fedlearn"
-
-# Cluster tenant names. Each tenant gets a dedicated nodepool, service accounts etc.
-tenant_names = ["fltenant1"]
-
-# GKE cluster created created in this region
-region = "europe-west1"
-# need to be from region above. Cluster nodes created in each zone.
-zones = ["europe-west1-b"]
-
-# Anthos Config Management
-# Update with your own repo URL, if you created one
-# For simplicity, repo is assumed to be publicly accessible ('none' secret)
-acm_repo_location = "https://github.com/GoogleCloudPlatform/gke-third-party-apps-blueprint"
-acm_secret_type   = "none"
-acm_branch        = "main"
-acm_dir           = "configsync"
-
-project_id = ""
+# Uncomment the following variable and set its value to point to your own Google Cloud project id
+# project_id = ""

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,114 +4,135 @@ variable "project_id" {
 }
 
 variable "region" {
+  default     = "europe-west1"
   description = "The region for clusters"
   type        = string
 }
 
 variable "zones" {
-  description = "The zones for clusters"
-  type        = list(any)
+  default     = ["europe-west1-b"]
+  description = "Cluster nodes will be created in each of the following zones. These zones need to be in the region specified by the 'region' variable."
+  type        = list(string)
 }
 
 variable "cluster_name" {
+  default     = "gke-third-party-workloads"
   description = "The GKE cluster name"
   type        = string
 }
 
 variable "tenant_names" {
-  description = "Set of named tenants to be created in the cluster. Each tenant gets a dedicated nodepool, service accounts etc"
-  type        = list(any)
+  default     = ["fltenant1"]
+  description = "Set of named tenants to be created in the cluster. Each tenant gets a dedicated resources."
+  type        = list(string)
 }
 
 variable "master_ipv4_cidr_block" {
   description = "The IP range in CIDR notation to use for the hosted master network"
   default     = "10.0.0.0/28"
+  type        = string
 }
 
 variable "cluster_default_pool_machine_type" {
   description = "The machine type for a default node pool"
-  type        = string
   default     = "e2-standard-4"
+  type        = string
 }
 
 variable "cluster_default_pool_min_nodes" {
   description = "The min number of nodes in the default node pool"
   default     = 3
+  type        = number
 }
 
 variable "cluster_default_pool_max_nodes" {
   description = "The min number of nodes in the default node pool"
   default     = 5
+  type        = number
 }
 
 variable "cluster_gke_release_channel" {
   default     = "REGULAR"
   description = "Release channel of the GKE cluster"
+  type        = string
 }
 
 variable "cluster_regional" {
-  default     = false
+  default     = true
   description = "Set to true to provision a regional GKE cluster"
+  type        = bool
 }
 
 variable "cluster_tenant_pool_machine_type" {
   description = "The machine type for a tenant node pool"
-  type        = string
   default     = "e2-standard-4"
+  type        = string
 }
 
 variable "cluster_tenant_pool_min_nodes" {
   description = "The min number of nodes in the tenant node pool"
   default     = 2
+  type        = number
 }
 
 variable "cluster_tenant_pool_max_nodes" {
   description = "The min number of nodes in the tenant node pool"
   default     = 5
+  type        = number
 }
 
 variable "cluster_secrets_keyname" {
   description = "The name of the Cloud KMS key used to encrypt cluster secrets"
-  type        = string
   default     = "clusterSecretsKey"
+  type        = string
 }
 
 variable "acm_version" {
-  description = "ACM version"
+  description = "Anthos Config Management version"
   default     = "1.9.0"
+  type        = string
 }
 
 variable "acm_repo_location" {
-  description = "The location of the git repo ACM will sync to"
+  default     = "https://github.com/GoogleCloudPlatform/gke-third-party-apps-blueprint"
+  description = "The location of the Git repo Anthos Config Management will sync to"
+  type        = string
 }
 
 variable "acm_branch" {
-  description = "The git branch ACM will sync to"
+  default     = "main"
+  description = "The Git branch Anthos Config Management will sync to"
+  type        = string
 }
 
 variable "acm_dir" {
-  description = "The directory in git ACM will sync to"
+  default     = "configsync"
+  description = "The directory in the repository that Anthos Config Management will sync to"
+  type        = string
 }
 
 variable "acm_secret_type" {
-  description = "git authentication secret type"
   default     = "none"
+  description = "Git authentication secret type. The default value assumes that the repository is publicly accessible."
+  type        = string
 }
 
 variable "acm_create_ssh_key" {
   description = "Controls whether a key will be generated for Git authentication"
   default     = false
+  type        = bool
 }
 
 variable "asm_release_channel" {
   description = "Anthos Service Mesh release channel. See https://cloud.google.com/service-mesh/docs/managed/select-a-release-channel for more information"
   default     = "regular"
+  type        = string
 }
 
 variable "asm_enable_mesh_feature" {
   description = "Set to true to enable Anthos Service Mesh feature. It is required to install the ASM CRDs."
-  type        = bool
   default     = true
+  type        = bool
 }
 
 variable "gke_rbac_security_group_domain" {


### PR DESCRIPTION
This PR does the following:

- Move default Terraform variables values from `terraform.tfvars` file to `variables.tf` to make use of Terraform variable precedence and to centralize variable initialization and descriptions.
- Make setting the `project_id` variable required from the start by not setting a default (empty) value for it. This makes Terraform validation commands more useful because they can now catch it if it's not set.
- Set type constraints for Terraform variables.
- Update the README to set the Terraform project and to clarify some details.
- Set the GKE cluster to be regional by default instead of zonal.