### PR TITLE
Use the Terraform Google Cloud VPC module and start managing main node pool service account

### DIFF
--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -5,6 +5,6 @@ module "asm" {
   channel             = var.asm_release_channel
   cluster_location    = module.gke.location
   cluster_name        = module.gke.name
-  project_id          = var.project_id
+  project_id          = data.google_project.project.project_id
   enable_mesh_feature = var.asm_enable_mesh_feature
 }

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -13,7 +13,7 @@ resource "google_dns_managed_zone" "private-google-apis" {
 
   private_visibility_config {
     networks {
-      network_url = google_compute_network.vpc.id
+      network_url = module.fedlearn-vpc.network_id
     }
   }
 }
@@ -44,7 +44,7 @@ resource "google_dns_managed_zone" "private-container-registry" {
 
   private_visibility_config {
     networks {
-      network_url = google_compute_network.vpc.id
+      network_url = module.fedlearn-vpc.network_id
     }
   }
 }
@@ -75,7 +75,7 @@ resource "google_dns_managed_zone" "private-artifact-registry" {
 
   private_visibility_config {
     networks {
-      network_url = google_compute_network.vpc.id
+      network_url = module.fedlearn-vpc.network_id
     }
   }
 }

--- a/terraform/firewall.tf
+++ b/terraform/firewall.tf
@@ -9,7 +9,7 @@ locals {
 resource "google_compute_firewall" "tenantpools-deny-egress" {
   name                    = "tenantpools-deny-egress"
   description             = "Default deny egress from tenant nodepools"
-  project                 = var.project_id
+  project                 = data.google_project.project.project_id
   network                 = module.fedlearn-vpc.network_id
   direction               = "EGRESS"
   target_service_accounts = local.list_tenant_nodepool_sa
@@ -22,7 +22,7 @@ resource "google_compute_firewall" "tenantpools-deny-egress" {
 resource "google_compute_firewall" "tenantpools-allow-egress-nodes-pods-services" {
   name                    = "tenantpools-allow-egress-nodes-pods-services"
   description             = "Allow egress from tenant nodepools to cluster nodes, pods and services"
-  project                 = var.project_id
+  project                 = data.google_project.project.project_id
   network                 = module.fedlearn-vpc.network_id
   direction               = "EGRESS"
   target_service_accounts = local.list_tenant_nodepool_sa
@@ -36,7 +36,7 @@ resource "google_compute_firewall" "tenantpools-allow-egress-nodes-pods-services
 resource "google_compute_firewall" "tenantpools-allow-egress-api-server" {
   name                    = "tenantpools-allow-egress-api-server"
   description             = "Allow egress from tenant nodepools to the Kubernetes API server"
-  project                 = var.project_id
+  project                 = data.google_project.project.project_id
   network                 = module.fedlearn-vpc.network_id
   direction               = "EGRESS"
   target_service_accounts = local.list_tenant_nodepool_sa
@@ -51,7 +51,7 @@ resource "google_compute_firewall" "tenantpools-allow-egress-api-server" {
 resource "google_compute_firewall" "tenantpools-allow-egress-google-apis" {
   name                    = "tenantpools-allow-egress-google-apis"
   description             = "Allow egress from tenant nodepools to Google APIs (private Google access)"
-  project                 = var.project_id
+  project                 = data.google_project.project.project_id
   network                 = module.fedlearn-vpc.network_id
   direction               = "EGRESS"
   target_service_accounts = local.list_tenant_nodepool_sa
@@ -67,7 +67,7 @@ resource "google_compute_firewall" "tenantpools-allow-egress-google-apis" {
 # See https://cloud.google.com/iap/docs/using-tcp-forwarding#create-firewall-rule
 resource "google_compute_firewall" "allow-ssh-tunnel-iap" {
   name      = "allow-ssh-tunnel-iap"
-  project   = var.project_id
+  project   = data.google_project.project.project_id
   network   = module.fedlearn-vpc.network_id
   direction = "INGRESS"
   # This range contains all IP addresses that IAP uses for TCP forwarding.

--- a/terraform/firewall.tf
+++ b/terraform/firewall.tf
@@ -26,7 +26,7 @@ resource "google_compute_firewall" "tenantpools-allow-egress-nodes-pods-services
   network                 = module.fedlearn-vpc.network_id
   direction               = "EGRESS"
   target_service_accounts = local.list_tenant_nodepool_sa
-  destination_ranges      = [module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].subnet_ip, "10.20.0.0/14", "10.24.0.0/20"]
+  destination_ranges      = [module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].ip_cidr_range, local.fedlearn_pods_ip_range, local.fedlearn_services_ip_range]
   allow {
     protocol = "all"
   }

--- a/terraform/firewall.tf
+++ b/terraform/firewall.tf
@@ -10,7 +10,7 @@ resource "google_compute_firewall" "tenantpools-deny-egress" {
   name                    = "tenantpools-deny-egress"
   description             = "Default deny egress from tenant nodepools"
   project                 = var.project_id
-  network                 = google_compute_network.vpc.name
+  network                 = module.fedlearn-vpc.network_id
   direction               = "EGRESS"
   target_service_accounts = local.list_tenant_nodepool_sa
   deny {
@@ -23,10 +23,10 @@ resource "google_compute_firewall" "tenantpools-allow-egress-nodes-pods-services
   name                    = "tenantpools-allow-egress-nodes-pods-services"
   description             = "Allow egress from tenant nodepools to cluster nodes, pods and services"
   project                 = var.project_id
-  network                 = google_compute_network.vpc.name
+  network                 = module.fedlearn-vpc.network_id
   direction               = "EGRESS"
   target_service_accounts = local.list_tenant_nodepool_sa
-  destination_ranges      = [google_compute_subnetwork.subnet.ip_cidr_range, "10.20.0.0/14", "10.24.0.0/20"]
+  destination_ranges      = [module.fedlearn-vpc.subnets[local.fedlearn_subnet_name].subnet_ip, "10.20.0.0/14", "10.24.0.0/20"]
   allow {
     protocol = "all"
   }
@@ -37,7 +37,7 @@ resource "google_compute_firewall" "tenantpools-allow-egress-api-server" {
   name                    = "tenantpools-allow-egress-api-server"
   description             = "Allow egress from tenant nodepools to the Kubernetes API server"
   project                 = var.project_id
-  network                 = google_compute_network.vpc.name
+  network                 = module.fedlearn-vpc.network_id
   direction               = "EGRESS"
   target_service_accounts = local.list_tenant_nodepool_sa
   destination_ranges      = [var.master_ipv4_cidr_block]
@@ -52,7 +52,7 @@ resource "google_compute_firewall" "tenantpools-allow-egress-google-apis" {
   name                    = "tenantpools-allow-egress-google-apis"
   description             = "Allow egress from tenant nodepools to Google APIs (private Google access)"
   project                 = var.project_id
-  network                 = google_compute_network.vpc.name
+  network                 = module.fedlearn-vpc.network_id
   direction               = "EGRESS"
   target_service_accounts = local.list_tenant_nodepool_sa
   destination_ranges      = ["199.36.153.8/30"]
@@ -68,7 +68,7 @@ resource "google_compute_firewall" "tenantpools-allow-egress-google-apis" {
 resource "google_compute_firewall" "allow-ssh-tunnel-iap" {
   name      = "allow-ssh-tunnel-iap"
   project   = var.project_id
-  network   = google_compute_network.vpc.name
+  network   = module.fedlearn-vpc.network_id
   direction = "INGRESS"
   # This range contains all IP addresses that IAP uses for TCP forwarding.
   source_ranges = ["35.235.240.0/20"]

--- a/terraform/firewall.tf
+++ b/terraform/firewall.tf
@@ -26,7 +26,7 @@ resource "google_compute_firewall" "tenantpools-allow-egress-nodes-pods-services
   network                 = module.fedlearn-vpc.network_id
   direction               = "EGRESS"
   target_service_accounts = local.list_tenant_nodepool_sa
-  destination_ranges      = [module.fedlearn-vpc.subnets[local.fedlearn_subnet_name].subnet_ip, "10.20.0.0/14", "10.24.0.0/20"]
+  destination_ranges      = [module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].subnet_ip, "10.20.0.0/14", "10.24.0.0/20"]
   allow {
     protocol = "all"
   }

--- a/terraform/firewall.tf
+++ b/terraform/firewall.tf
@@ -1,31 +1,32 @@
 locals {
-  # list of dedicated service accounts used by the tenant nodepools
-  list_tenant_nodepool_sa = [
-    for sa in google_service_account.tenant_nodepool_sa : sa.email
-  ]
+  # list of dedicated service accounts used by the tenant node pools and the main node pool
+  list_nodepool_sa = concat(
+    [for sa in google_service_account.tenant_nodepool_sa : sa.email],
+    [google_service_account.main_nodepool_sa.email]
+  )
 }
 
 # deny all egress from the FL node pool
-resource "google_compute_firewall" "tenantpools-deny-egress" {
-  name                    = "tenantpools-deny-egress"
-  description             = "Default deny egress from tenant nodepools"
+resource "google_compute_firewall" "node-pools-deny-egress" {
+  name                    = "node-pools-deny-egress"
+  description             = "Default deny egress from node pools"
   project                 = data.google_project.project.project_id
   network                 = module.fedlearn-vpc.network_id
   direction               = "EGRESS"
-  target_service_accounts = local.list_tenant_nodepool_sa
+  target_service_accounts = local.list_nodepool_sa
   deny {
     protocol = "all"
   }
   priority = 65535
 }
 
-resource "google_compute_firewall" "tenantpools-allow-egress-nodes-pods-services" {
-  name                    = "tenantpools-allow-egress-nodes-pods-services"
-  description             = "Allow egress from tenant nodepools to cluster nodes, pods and services"
+resource "google_compute_firewall" "node-pools-allow-egress-nodes-pods-services" {
+  name                    = "node-pools-allow-egress-nodes-pods-services"
+  description             = "Allow egress from node pools to cluster nodes, pods and services"
   project                 = data.google_project.project.project_id
   network                 = module.fedlearn-vpc.network_id
   direction               = "EGRESS"
-  target_service_accounts = local.list_tenant_nodepool_sa
+  target_service_accounts = local.list_nodepool_sa
   destination_ranges      = [module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].ip_cidr_range, local.fedlearn_pods_ip_range, local.fedlearn_services_ip_range]
   allow {
     protocol = "all"
@@ -33,13 +34,13 @@ resource "google_compute_firewall" "tenantpools-allow-egress-nodes-pods-services
   priority = 1000
 }
 
-resource "google_compute_firewall" "tenantpools-allow-egress-api-server" {
-  name                    = "tenantpools-allow-egress-api-server"
-  description             = "Allow egress from tenant nodepools to the Kubernetes API server"
+resource "google_compute_firewall" "node-pools-allow-egress-api-server" {
+  name                    = "node-pools-allow-egress-api-server"
+  description             = "Allow egress from node pools to the Kubernetes API server"
   project                 = data.google_project.project.project_id
   network                 = module.fedlearn-vpc.network_id
   direction               = "EGRESS"
-  target_service_accounts = local.list_tenant_nodepool_sa
+  target_service_accounts = local.list_nodepool_sa
   destination_ranges      = [var.master_ipv4_cidr_block]
   allow {
     protocol = "tcp"
@@ -48,13 +49,13 @@ resource "google_compute_firewall" "tenantpools-allow-egress-api-server" {
   priority = 1000
 }
 
-resource "google_compute_firewall" "tenantpools-allow-egress-google-apis" {
-  name                    = "tenantpools-allow-egress-google-apis"
-  description             = "Allow egress from tenant nodepools to Google APIs (private Google access)"
+resource "google_compute_firewall" "node-pools-allow-egress-google-apis" {
+  name                    = "node-pools-allow-egress-google-apis"
+  description             = "Allow egress from node pools to Google APIs via Private Google Access"
   project                 = data.google_project.project.project_id
   network                 = module.fedlearn-vpc.network_id
   direction               = "EGRESS"
-  target_service_accounts = local.list_tenant_nodepool_sa
+  target_service_accounts = local.list_nodepool_sa
   destination_ranges      = ["199.36.153.8/30"]
   allow {
     protocol = "tcp"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -35,25 +35,28 @@ resource "google_service_account" "tenant_apps_sa" {
 
 # default roles for the node SAs
 module "project-iam-bindings" {
-  for_each = google_service_account.tenant_nodepool_sa
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
   version  = "7.6.0"
   projects = [data.google_project.project.project_id]
   mode     = "authoritative"
 
   bindings = {
-    "roles/logging.logWriter" = [
-      format("serviceAccount:%s", each.value.email)
-    ]
-    "roles/monitoring.metricWriter" = [
-      format("serviceAccount:%s", each.value.email)
-    ]
-    "roles/monitoring.viewer" = [
-      format("serviceAccount:%s", each.value.email)
-    ]
-    "roles/artifactregistry.reader" = [
-      format("serviceAccount:%s", each.value.email)
-    ]
+    "roles/logging.logWriter" = concat(
+      [for service_account in google_service_account.tenant_nodepool_sa : format("serviceAccount:%s", service_account.email)],
+      [format("serviceAccount:%s", google_service_account.main_nodepool_sa.email)]
+    )
+    "roles/monitoring.metricWriter" = concat(
+      [for service_account in google_service_account.tenant_nodepool_sa : format("serviceAccount:%s", service_account.email)],
+      [format("serviceAccount:%s", google_service_account.main_nodepool_sa.email)]
+    )
+    "roles/monitoring.viewer" = concat(
+      [for service_account in google_service_account.tenant_nodepool_sa : format("serviceAccount:%s", service_account.email)],
+      [format("serviceAccount:%s", google_service_account.main_nodepool_sa.email)]
+    )
+    "roles/artifactregistry.reader" = concat(
+      [for service_account in google_service_account.tenant_nodepool_sa : format("serviceAccount:%s", service_account.email)],
+      [format("serviceAccount:%s", google_service_account.main_nodepool_sa.email)]
+    )
   }
 
   depends_on = [

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -13,7 +13,7 @@ resource "google_service_account" "tenant_nodepool_sa" {
 # Service Account used by the nodes in the main node pool
 resource "google_service_account" "main_nodepool_sa" {
   project      = data.google_project.project.project_id
-  account_id   = format("%s-%s-nodes-sa", var.cluster_name, local.main_node_pool_name)
+  account_id   = local.main_node_pool_sa_name
   display_name = "Service account for ${local.main_node_pool_name} node pool in cluster ${var.cluster_name}"
 
   depends_on = [

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -35,7 +35,7 @@ resource "google_service_account" "tenant_apps_sa" {
 
 # default roles for the node SAs
 module "project-iam-bindings" {
-  for_each = concat(google_service_account.tenant_nodepool_sa, [google_service_account.main_nodepool_sa])
+  for_each = google_service_account.tenant_nodepool_sa
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
   version  = "7.6.0"
   projects = [data.google_project.project.project_id]
@@ -43,8 +43,7 @@ module "project-iam-bindings" {
 
   bindings = {
     "roles/logging.logWriter" = [
-      format("serviceAccount:%s", each.value.email),
-
+      format("serviceAccount:%s", each.value.email)
     ]
     "roles/monitoring.metricWriter" = [
       format("serviceAccount:%s", each.value.email)

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,7 +1,7 @@
 # Service Account used by the nodes in a tenant node pool
 resource "google_service_account" "tenant_nodepool_sa" {
   for_each     = local.tenants
-  project      = var.project_id
+  project      = data.google_project.project.project_id
   account_id   = each.value.tenant_nodepool_sa_name
   display_name = "Service account for ${each.key} node pool in cluster ${var.cluster_name}"
 
@@ -13,7 +13,7 @@ resource "google_service_account" "tenant_nodepool_sa" {
 # Service Account used by apps in a tenant namespace
 resource "google_service_account" "tenant_apps_sa" {
   for_each     = local.tenants
-  project      = var.project_id
+  project      = data.google_project.project.project_id
   account_id   = each.value.tenant_apps_sa_name
   display_name = "Service account for ${each.key} apps in cluster ${var.cluster_name}"
 
@@ -27,7 +27,7 @@ module "project-iam-bindings" {
   for_each = google_service_account.tenant_nodepool_sa
   source   = "terraform-google-modules/iam/google//modules/projects_iam"
   version  = "7.6.0"
-  projects = [var.project_id]
+  projects = [data.google_project.project.project_id]
   mode     = "authoritative"
 
   bindings = {
@@ -57,7 +57,7 @@ resource "google_service_account_iam_binding" "workload_identity" {
   role               = "roles/iam.workloadIdentityUser"
 
   members = [
-    format("serviceAccount:%s.svc.id.goog[%s/ksa]", var.project_id, each.key),
+    format("serviceAccount:%s.svc.id.goog[%s/ksa]", data.google_project.project.project_id, each.key),
   ]
   # workload identity pool must exist before binding
   depends_on = [

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -41,6 +41,7 @@ module "project-iam-bindings" {
   mode     = "authoritative"
 
   bindings = {
+    # Least-privilege roles needed for a node pool service account to function
     "roles/logging.logWriter" = concat(
       [for service_account in google_service_account.tenant_nodepool_sa : format("serviceAccount:%s", service_account.email)],
       [format("serviceAccount:%s", google_service_account.main_nodepool_sa.email)]
@@ -53,6 +54,11 @@ module "project-iam-bindings" {
       [for service_account in google_service_account.tenant_nodepool_sa : format("serviceAccount:%s", service_account.email)],
       [format("serviceAccount:%s", google_service_account.main_nodepool_sa.email)]
     )
+    "roles/stackdriver.resourceMetadata.writer" = concat(
+      [for service_account in google_service_account.tenant_nodepool_sa : format("serviceAccount:%s", service_account.email)],
+      [format("serviceAccount:%s", google_service_account.main_nodepool_sa.email)]
+    )
+    # Grant node pool service accounts read access to Container Registry and Artifact Registry
     "roles/artifactregistry.reader" = concat(
       [for service_account in google_service_account.tenant_nodepool_sa : format("serviceAccount:%s", service_account.email)],
       [format("serviceAccount:%s", google_service_account.main_nodepool_sa.email)]

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -14,7 +14,7 @@ resource "google_service_account" "tenant_nodepool_sa" {
 resource "google_service_account" "main_nodepool_sa" {
   project      = data.google_project.project.project_id
   account_id   = format("%s-%s-nodes-sa", var.cluster_name, local.main_node_pool_name)
-  display_name = "Service account for ${each.key} node pool in cluster ${var.cluster_name}"
+  display_name = "Service account for ${local.main_node_pool_name} node pool in cluster ${var.cluster_name}"
 
   depends_on = [
     module.project-services

--- a/terraform/kms.tf
+++ b/terraform/kms.tf
@@ -1,25 +1,66 @@
-module "kms" {
-  source  = "terraform-google-modules/kms/google"
-  version = "2.2.2"
-
-  project_id = var.project_id
-  location   = var.region
-  keyring    = "keyring-${random_id.keyring_suffix.hex}"
-  keys       = [var.cluster_secrets_keyname]
-
-  # IAM
-  set_encrypters_for = [var.cluster_secrets_keyname]
-  set_decrypters_for = [var.cluster_secrets_keyname]
-  encrypters         = ["serviceAccount:${local.gke_robot_sa}"]
-  decrypters         = ["serviceAccount:${local.gke_robot_sa}"]
-  prevent_destroy    = false
+# Service Account used by the nodes in a tenant node pool
+resource "google_service_account" "tenant_nodepool_sa" {
+  for_each     = local.tenants
+  project      = data.google_project.project.project_id
+  account_id   = each.value.tenant_nodepool_sa_name
+  display_name = "Service account for ${each.key} node pool in cluster ${var.cluster_name}"
 
   depends_on = [
     module.project-services
   ]
 }
 
-# KeyRings cannot be deleted; append a suffix to name
-resource "random_id" "keyring_suffix" {
-  byte_length = 4
+# Service Account used by apps in a tenant namespace
+resource "google_service_account" "tenant_apps_sa" {
+  for_each     = local.tenants
+  project      = data.google_project.project.project_id
+  account_id   = each.value.tenant_apps_sa_name
+  display_name = "Service account for ${each.key} apps in cluster ${var.cluster_name}"
+
+  depends_on = [
+    module.project-services
+  ]
+}
+
+# default roles for the node SAs
+module "project-iam-bindings" {
+  for_each = google_service_account.tenant_nodepool_sa
+  source   = "terraform-google-modules/iam/google//modules/projects_iam"
+  version  = "7.6.0"
+  projects = [data.google_project.project.project_id]
+  mode     = "authoritative"
+
+  bindings = {
+    "roles/logging.logWriter" = [
+      format("serviceAccount:%s", each.value.email)
+    ]
+    "roles/monitoring.metricWriter" = [
+      format("serviceAccount:%s", each.value.email)
+    ]
+    "roles/monitoring.viewer" = [
+      format("serviceAccount:%s", each.value.email)
+    ]
+    "roles/artifactregistry.reader" = [
+      format("serviceAccount:%s", each.value.email)
+    ]
+  }
+
+  depends_on = [
+    module.project-services
+  ]
+}
+
+# enable the tenant apps service accounts for Workload Identity
+resource "google_service_account_iam_binding" "workload_identity" {
+  for_each           = google_service_account.tenant_apps_sa
+  service_account_id = each.value.name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    format("serviceAccount:%s.svc.id.goog[%s/ksa]", data.google_project.project.project_id, each.key),
+  ]
+  # workload identity pool must exist before binding
+  depends_on = [
+    module.gke
+  ]
 }

--- a/terraform/kms.tf
+++ b/terraform/kms.tf
@@ -1,66 +1,25 @@
-# Service Account used by the nodes in a tenant node pool
-resource "google_service_account" "tenant_nodepool_sa" {
-  for_each     = local.tenants
-  project      = data.google_project.project.project_id
-  account_id   = each.value.tenant_nodepool_sa_name
-  display_name = "Service account for ${each.key} node pool in cluster ${var.cluster_name}"
+module "kms" {
+  source  = "terraform-google-modules/kms/google"
+  version = "2.2.2"
+
+  project_id = data.google_project.project.project_id
+  location   = var.region
+  keyring    = "keyring-${random_id.keyring_suffix.hex}"
+  keys       = [var.cluster_secrets_keyname]
+
+  # IAM
+  set_encrypters_for = [var.cluster_secrets_keyname]
+  set_decrypters_for = [var.cluster_secrets_keyname]
+  encrypters         = ["serviceAccount:${local.gke_robot_sa}"]
+  decrypters         = ["serviceAccount:${local.gke_robot_sa}"]
+  prevent_destroy    = false
 
   depends_on = [
     module.project-services
   ]
 }
 
-# Service Account used by apps in a tenant namespace
-resource "google_service_account" "tenant_apps_sa" {
-  for_each     = local.tenants
-  project      = data.google_project.project.project_id
-  account_id   = each.value.tenant_apps_sa_name
-  display_name = "Service account for ${each.key} apps in cluster ${var.cluster_name}"
-
-  depends_on = [
-    module.project-services
-  ]
-}
-
-# default roles for the node SAs
-module "project-iam-bindings" {
-  for_each = google_service_account.tenant_nodepool_sa
-  source   = "terraform-google-modules/iam/google//modules/projects_iam"
-  version  = "7.6.0"
-  projects = [data.google_project.project.project_id]
-  mode     = "authoritative"
-
-  bindings = {
-    "roles/logging.logWriter" = [
-      format("serviceAccount:%s", each.value.email)
-    ]
-    "roles/monitoring.metricWriter" = [
-      format("serviceAccount:%s", each.value.email)
-    ]
-    "roles/monitoring.viewer" = [
-      format("serviceAccount:%s", each.value.email)
-    ]
-    "roles/artifactregistry.reader" = [
-      format("serviceAccount:%s", each.value.email)
-    ]
-  }
-
-  depends_on = [
-    module.project-services
-  ]
-}
-
-# enable the tenant apps service accounts for Workload Identity
-resource "google_service_account_iam_binding" "workload_identity" {
-  for_each           = google_service_account.tenant_apps_sa
-  service_account_id = each.value.name
-  role               = "roles/iam.workloadIdentityUser"
-
-  members = [
-    format("serviceAccount:%s.svc.id.goog[%s/ksa]", data.google_project.project.project_id, each.key),
-  ]
-  # workload identity pool must exist before binding
-  depends_on = [
-    module.gke
-  ]
+# KeyRings cannot be deleted; append a suffix to name
+resource "random_id" "keyring_suffix" {
+  byte_length = 4
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,7 +16,7 @@ module "gke" {
 
   authenticator_security_group = var.gke_rbac_security_group_domain != null ? "gke-security-groups@${var.gke_rbac_security_group_domain}" : null
 
-  project_id        = var.project_id
+  project_id        = data.google_project.project.project_id
   name              = var.cluster_name
   release_channel   = var.cluster_gke_release_channel
   regional          = var.cluster_regional
@@ -90,7 +90,7 @@ module "gke" {
       # enable GKE sandbox (gVisor) for tenant nodes
       sandbox_enabled = true
       # dedicated service account per tenant node pool
-      service_account = format("%s@%s.iam.gserviceaccount.com", config.tenant_nodepool_sa_name, var.project_id)
+      service_account = format("%s@%s.iam.gserviceaccount.com", config.tenant_nodepool_sa_name, data.google_project.project.project_id)
     }]
   )
 
@@ -130,7 +130,11 @@ data "google_project" "project" {
   project_id = var.project_id
 }
 
-data "google_client_config" "default" {}
+data "google_client_config" "default" {
+  depends_on = [
+    module.project-services
+  ]
+}
 
 provider "kubernetes" {
   host                   = "https://${module.gke.endpoint}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -67,7 +67,7 @@ module "gke" {
   node_pools = concat(
     # main node pool
     [{
-      name                        = "main-pool"
+      name                        = local.main_node_pool_name
       image_type                  = "COS_CONTAINERD"
       machine_type                = var.cluster_default_pool_machine_type
       min_count                   = var.cluster_default_pool_min_nodes
@@ -75,6 +75,7 @@ module "gke" {
       auto_upgrade                = true
       enable_integrity_monitoring = true
       enable_secure_boot          = true
+      service_account             = google_service_account.main_nodepool_sa.email
     }],
 
     # list of tenant nodepools
@@ -110,11 +111,14 @@ module "gke" {
 
   depends_on = [
     module.project-services,
+    google_service_account.main_nodepool_sa,
     google_service_account.tenant_nodepool_sa
   ]
 }
 
 locals {
+  main_node_pool_name = "main-pool"
+
   # for each tenant, define the names of the nodepool, service accounts etc
   tenants = {
     for name in var.tenant_names : name => {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,7 +22,7 @@ module "gke" {
   regional          = var.cluster_regional
   region            = var.region
   zones             = var.zones
-  network           = google_compute_network.vpc.name
+  network           = module.fedlearn-vpc.network_id
   subnetwork        = google_compute_subnetwork.subnet.name
   ip_range_pods     = "pods"
   ip_range_services = "services"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -110,6 +110,7 @@ module "gke" {
   }
 
   depends_on = [
+    module.project-iam-bindings,
     module.project-services,
     google_service_account.main_nodepool_sa,
     google_service_account.tenant_nodepool_sa

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,7 +23,7 @@ module "gke" {
   region            = var.region
   zones             = var.zones
   network           = module.fedlearn-vpc.network_id
-  subnetwork        = module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].self_link
+  subnetwork        = module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].name
   ip_range_pods     = "pods"
   ip_range_services = "services"
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,7 +22,7 @@ module "gke" {
   regional          = var.cluster_regional
   region            = var.region
   zones             = var.zones
-  network           = module.fedlearn-vpc.network_id
+  network           = module.fedlearn-vpc.network_name
   subnetwork        = module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].name
   ip_range_pods     = "pods"
   ip_range_services = "services"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,7 +75,7 @@ module "gke" {
       auto_upgrade                = true
       enable_integrity_monitoring = true
       enable_secure_boot          = true
-      service_account             = google_service_account.main_nodepool_sa.email
+      service_account             = format("%s@%s.iam.gserviceaccount.com", local.main_node_pool_sa_name, data.google_project.project.project_id)
     }],
 
     # list of tenant nodepools
@@ -117,7 +117,8 @@ module "gke" {
 }
 
 locals {
-  main_node_pool_name = "main-pool"
+  main_node_pool_name    = "main-pool"
+  main_node_pool_sa_name = format("%s-%s-nodes-sa", var.cluster_name, local.main_node_pool_name)
 
   # for each tenant, define the names of the nodepool, service accounts etc
   tenants = {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -112,8 +112,12 @@ module "gke" {
   depends_on = [
     module.project-iam-bindings,
     module.project-services,
+    google_compute_firewall.node-pools-deny-egress,
+    google_compute_firewall.node-pools-allow-egress-nodes-pods-services,
+    google_compute_firewall.node-pools-allow-egress-api-server,
+    google_compute_firewall.node-pools-allow-egress-google-apis,
     google_service_account.main_nodepool_sa,
-    google_service_account.tenant_nodepool_sa
+    google_service_account.tenant_nodepool_sa,
   ]
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,7 +23,7 @@ module "gke" {
   region            = var.region
   zones             = var.zones
   network           = module.fedlearn-vpc.network_id
-  subnetwork        = google_compute_subnetwork.subnet.name
+  subnetwork        = module.fedlearn-vpc.subnets[local.fedlearn_subnet_name].self_link
   ip_range_pods     = "pods"
   ip_range_services = "services"
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -128,13 +128,13 @@ locals {
 
 data "google_project" "project" {
   project_id = var.project_id
-}
 
-data "google_client_config" "default" {
   depends_on = [
     module.project-services
   ]
 }
+
+data "google_client_config" "default" {}
 
 provider "kubernetes" {
   host                   = "https://${module.gke.endpoint}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,7 +23,7 @@ module "gke" {
   region            = var.region
   zones             = var.zones
   network           = module.fedlearn-vpc.network_id
-  subnetwork        = module.fedlearn-vpc.subnets[local.fedlearn_subnet_name].self_link
+  subnetwork        = module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].self_link
   ip_range_pods     = "pods"
   ip_range_services = "services"
 

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,6 +1,6 @@
 locals {
   fedlearn_subnet_name = "subnet-01"
-  fedlearn_subnet_key  = "${var.region}/${fedlearn_subnet_name}"
+  fedlearn_subnet_key  = "${var.region}/${local.fedlearn_subnet_name}"
 }
 
 

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -2,7 +2,7 @@ locals {
   fedlearn_subnet_name = "subnet-01"
   fedlearn_subnet_key  = "${var.region}/${local.fedlearn_subnet_name}"
 
-  fedlearn_pods_ip_range = "10.20.0.0/14"
+  fedlearn_pods_ip_range     = "10.20.0.0/14"
   fedlearn_services_ip_range = "10.24.0.0/20"
 }
 

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,38 +1,52 @@
-resource "google_compute_network" "vpc" {
-  name                    = "fedlearn-network"
-  project                 = var.project_id
-  auto_create_subnetworks = false
+locals {
+  fedlearn_subnet_name = "subnet-01"
+}
+
+
+module "fedlearn-vpc" {
+  source  = "terraform-google-modules/network/google"
+  version = "7.0.0"
+
+  delete_default_internet_gateway_routes = true
+  project_id                             = var.project_id
+  network_name                           = "fedlearn-network"
+  routing_mode                           = "GLOBAL"
+
+  subnets = [
+    {
+      subnet_name   = local.fedlearn_subnet_name
+      subnet_ip     = "10.2.0.0/16"
+      subnet_region = var.region
+    }
+  ]
+
+  secondary_ranges = {
+    subnet-01 = [
+      {
+        range_name    = "pods"
+        ip_cidr_range = "10.20.0.0/14"
+      },
+      {
+        range_name    = "services"
+        ip_cidr_range = "10.24.0.0/20"
+      },
+    ]
+  }
 
   depends_on = [
     module.project-services
   ]
 }
 
-resource "google_compute_subnetwork" "subnet" {
-  name                     = "subnet-01"
-  ip_cidr_range            = "10.2.0.0/16"
-  region                   = var.region
-  network                  = google_compute_network.vpc.id
-  private_ip_google_access = true
-  secondary_ip_range {
-    range_name    = "pods"
-    ip_cidr_range = "10.20.0.0/14"
-  }
-  secondary_ip_range {
-    range_name    = "services"
-    ip_cidr_range = "10.24.0.0/20"
-  }
-}
-
 resource "google_compute_router" "router" {
   name    = "router"
-  region  = google_compute_subnetwork.subnet.region
-  network = google_compute_network.vpc.id
+  region  = module.fedlearn-vpc.subnets[local.fedlearn_subnet_name].subnet_region
+  network = module.fedlearn-vpc.network_id
 }
 
 resource "google_compute_address" "nat_ip" {
   name   = "nat-manual-ip"
-  region = google_compute_subnetwork.subnet.region
+  region = module.fedlearn-vpc.subnets[local.fedlearn_subnet_name].subnet_region
 }
 
 resource "google_compute_router_nat" "nat" {
@@ -45,7 +59,7 @@ resource "google_compute_router_nat" "nat" {
 
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
   subnetwork {
-    name                    = google_compute_subnetwork.subnet.id
+    name                    = module.fedlearn-vpc.subnets[local.fedlearn_subnet_name].self_link
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
 }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -18,9 +18,10 @@ module "fedlearn-vpc" {
 
   subnets = [
     {
-      subnet_name   = local.fedlearn_subnet_name
-      subnet_ip     = "10.2.0.0/16"
-      subnet_region = var.region
+      subnet_name           = local.fedlearn_subnet_name
+      subnet_ip             = "10.2.0.0/16"
+      subnet_private_access = "true"
+      subnet_region         = var.region
     }
   ]
 

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,6 +1,9 @@
 locals {
   fedlearn_subnet_name = "subnet-01"
   fedlearn_subnet_key  = "${var.region}/${local.fedlearn_subnet_name}"
+
+  fedlearn_pods_ip_range = "10.20.0.0/14"
+  fedlearn_services_ip_range = "10.24.0.0/20"
 }
 
 
@@ -25,11 +28,11 @@ module "fedlearn-vpc" {
     subnet-01 = [
       {
         range_name    = "pods"
-        ip_cidr_range = "10.20.0.0/14"
+        ip_cidr_range = local.fedlearn_pods_ip_range
       },
       {
         range_name    = "services"
-        ip_cidr_range = "10.24.0.0/20"
+        ip_cidr_range = local.fedlearn_services_ip_range
       },
     ]
   }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,5 +1,5 @@
 locals {
-  fedlearn_subnet_name = "subnet-01"
+  fedlearn_subnet_key = "${var.region}/subnet-01"
 }
 
 

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -9,7 +9,7 @@ module "fedlearn-vpc" {
   version = "7.0.0"
 
   delete_default_internet_gateway_routes = true
-  project_id                             = var.project_id
+  project_id                             = data.google_project.project.project_id
   network_name                           = "fedlearn-network"
   routing_mode                           = "GLOBAL"
 

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,5 +1,6 @@
 locals {
-  fedlearn_subnet_key = "${var.region}/subnet-01"
+  fedlearn_subnet_name = "subnet-01"
+  fedlearn_subnet_key  = "${var.region}/${fedlearn_subnet_name}"
 }
 
 
@@ -40,13 +41,13 @@ module "fedlearn-vpc" {
 
 resource "google_compute_router" "router" {
   name    = "router"
-  region  = module.fedlearn-vpc.subnets[local.fedlearn_subnet_name].subnet_region
+  region  = module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].subnet_region
   network = module.fedlearn-vpc.network_id
 }
 
 resource "google_compute_address" "nat_ip" {
   name   = "nat-manual-ip"
-  region = module.fedlearn-vpc.subnets[local.fedlearn_subnet_name].subnet_region
+  region = module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].subnet_region
 }
 
 resource "google_compute_router_nat" "nat" {
@@ -59,7 +60,7 @@ resource "google_compute_router_nat" "nat" {
 
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
   subnetwork {
-    name                    = module.fedlearn-vpc.subnets[local.fedlearn_subnet_name].self_link
+    name                    = module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].self_link
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
 }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -11,10 +11,9 @@ module "fedlearn-vpc" {
   source  = "terraform-google-modules/network/google"
   version = "7.0.0"
 
-  delete_default_internet_gateway_routes = true
-  project_id                             = data.google_project.project.project_id
-  network_name                           = "fedlearn-network"
-  routing_mode                           = "GLOBAL"
+  project_id   = data.google_project.project.project_id
+  network_name = "fedlearn-network"
+  routing_mode = "GLOBAL"
 
   subnets = [
     {

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -41,13 +41,13 @@ module "fedlearn-vpc" {
 
 resource "google_compute_router" "router" {
   name    = "router"
-  region  = module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].subnet_region
+  region  = module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].region
   network = module.fedlearn-vpc.network_id
 }
 
 resource "google_compute_address" "nat_ip" {
   name   = "nat-manual-ip"
-  region = module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].subnet_region
+  region = module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].region
 }
 
 resource "google_compute_router_nat" "nat" {

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -1,3 +1,15 @@
+module "project-services-cloud-resource-manager" {
+  source  = "terraform-google-modules/project-factory/google//modules/project_services"
+  version = "14.2.0"
+
+  project_id                  = var.project_id
+  disable_services_on_destroy = false
+  activate_apis = [
+    "cloudresourcemanager.googleapis.com"
+  ]
+}
+
+
 module "project-services" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
   version = "14.2.0"
@@ -9,7 +21,6 @@ module "project-services" {
     "anthosconfigmanagement.googleapis.com",
     "cloudbilling.googleapis.com",
     "cloudkms.googleapis.com",
-    "cloudresourcemanager.googleapis.com",
     "cloudtrace.googleapis.com",
     "compute.googleapis.com",
     "container.googleapis.com",
@@ -24,5 +35,9 @@ module "project-services" {
     "meshtelemetry.googleapis.com",
     "monitoring.googleapis.com",
     "stackdriver.googleapis.com"
+  ]
+
+  depends_on = [
+    module.project-services-cloud-resource-manager
   ]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,7 +16,7 @@ variable "zones" {
 }
 
 variable "cluster_name" {
-  default     = "gke-third-party-workloads"
+  default     = "tp-w"
   description = "The GKE cluster name"
   type        = string
 }


### PR DESCRIPTION
In this PR, we:

- Refactor the resources to provision VPCs and subnets to use the [Google Cloud network module](https://registry.terraform.io/modules/terraform-google-modules/network/google/latest).
- Start managing the "main node pool" service account.

Other fixes:

- Enable the `cloudresourcemanager` API before anything else because some Terraform resources depend on that API to be enabled.
- Make the `google_project.project` data source that depend on the `cloudresourcemanager` API to be enabled to avoid concurrency issues.
- Reference the `google_project.project` data source instead of the `var.project_id` variable for additional validation.
- Reduce duplication by referencing local variables for the GKE cluster subnet secondary ranges.
- Shorten the GKE cluster name to avoid validation errors when creating service accounts that depend on that name.
- Configure IAM bindings for service accounts before using them for the cluster node pools.
