### PR TITLE
Use the Terraform ACM submodule

### DIFF
--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -33,6 +33,7 @@ module "acm" {
 
 
   depends_on = [
+    module.gke,
     module.project-services
   ]
 }

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -24,7 +24,7 @@ module "acm" {
 
   configmanagement_version = var.acm_version
   create_metrics_gcp_sa    = true
-  enable_mutations         = true
+  enable_mutation          = true
   policy_dir               = var.acm_dir
   secret_type              = var.acm_secret_type
   source_format            = "unstructured"

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -16,7 +16,7 @@
 # https://cloud.google.com/blog/topics/anthos/using-terraform-to-enable-config-sync-on-a-gke-cluster
 module "acm" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/acm"
-  version = "26.1.1"
+  version = "27.0.0"
 
   project_id   = data.google_project.project.project_id
   cluster_name = module.gke.name

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -14,56 +14,25 @@
 
 # See the series of blog posts for details on enabling Anthos Config Management using Terraform
 # https://cloud.google.com/blog/topics/anthos/using-terraform-to-enable-config-sync-on-a-gke-cluster
+module "acm" {
+  source  = "terraform-google-modules/kubernetes-engine/google//modules/acm"
+  version = "26.1.1"
 
-resource "google_gke_hub_membership" "membership" {
-  membership_id = module.gke.name
-  endpoint {
-    gke_cluster {
-      resource_link = "//container.googleapis.com/${module.gke.cluster_id}"
-    }
-  }
-  provider = google-beta
+  project_id   = data.google_project.project.project_id
+  cluster_name = module.gke.name
+  location     = module.gke.location
 
-  depends_on = [
-    module.project-services
-  ]
-}
+  configmanagement_version = var.acm_version
+  create_metrics_gcp_sa    = true
+  enable_mutations         = true
+  policy_dir               = var.acm_dir
+  secret_type              = var.acm_secret_type
+  source_format            = "unstructured"
+  sync_repo                = var.acm_repo_location
+  sync_branch              = var.acm_branch
 
-resource "google_gke_hub_feature" "feature" {
-  name     = "configmanagement"
-  location = "global"
-  provider = google-beta
 
   depends_on = [
     module.project-services
-  ]
-}
-
-resource "google_gke_hub_feature_membership" "feature_member" {
-  location   = "global"
-  feature    = google_gke_hub_feature.feature.name
-  membership = google_gke_hub_membership.membership.membership_id
-  configmanagement {
-    version = var.acm_version
-    config_sync {
-      git {
-        sync_repo   = var.acm_repo_location
-        sync_branch = var.acm_branch
-        policy_dir  = var.acm_dir
-        secret_type = var.acm_secret_type
-      }
-      source_format = "unstructured"
-    }
-    # Note that we enable PolicyController mutations separately below
-    policy_controller {
-      enabled                    = true
-      mutation_enabled           = true
-      template_library_installed = true
-    }
-  }
-  provider = google-beta
-
-  depends_on = [
-    module.asm.asm_wait,
   ]
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -17,15 +17,15 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.20.0, <5.0.0"
+      version = ">= 4.69.1, <5.0.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.20.0, <5.0.0"
+      version = ">= 4.69.1, <5.0.0"
     }
     http = {
       source  = "hashicorp/http"
-      version = ">= 2.2.0, < 4.0.0"
+      version = ">= 3.3.0, < 4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -33,7 +33,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.3.1, <4.0.0"
+      version = ">= 3.5.1, <4.0.0"
     }
   }
 }


### PR DESCRIPTION
In this PR we:

- Refactor Anthos Config Management resources to use the Terraform ACM submodule.

Dependencies:

- https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/1665
- https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/1658