### PR TITLE
Use the Terraform Cloud DNS module

### DIFF
--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -21,7 +21,7 @@ module "cloud-dns-private-google-apis" {
 
   recordsets = [
     {
-      name = "*.googleapis.com."
+      name = "*"
       type = "CNAME"
       ttl  = 300
       records = [
@@ -29,7 +29,7 @@ module "cloud-dns-private-google-apis" {
       ]
     },
     {
-      name    = "private.googleapis.com."
+      name    = "private"
       type    = "A"
       ttl     = 300
       records = local.private_google_access_ips
@@ -53,7 +53,7 @@ module "cloud-dns-private-container-registry" {
 
   recordsets = [
     {
-      name = "*.gcr.io."
+      name = "*"
       type = "CNAME"
       ttl  = 300
       records = [
@@ -61,7 +61,7 @@ module "cloud-dns-private-container-registry" {
       ]
     },
     {
-      name    = "gcr.io."
+      name    = ""
       type    = "A"
       ttl     = 300
       records = local.private_google_access_ips
@@ -85,7 +85,7 @@ module "cloud-dns-private-artifact-registry" {
 
   recordsets = [
     {
-      name = "*.pkg.dev."
+      name = "*"
       type = "CNAME"
       ttl  = 300
       records = [
@@ -93,7 +93,7 @@ module "cloud-dns-private-artifact-registry" {
       ]
     },
     {
-      name    = "pkg.dev."
+      name    = ""
       type    = "A"
       ttl     = 300
       records = local.private_google_access_ips

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -5,93 +5,98 @@ locals {
   ]
 }
 
-resource "google_dns_managed_zone" "private-google-apis" {
-  name        = "private-google-apis"
-  dns_name    = "googleapis.com."
+module "cloud-dns-private-google-apis" {
+  source  = "terraform-google-modules/cloud-dns/google"
+  version = "5.0.0"
+
   description = "Private DNS zone for Google APIs"
-  visibility  = "private"
+  domain      = "googleapis.com."
+  name        = "private-google-apis"
+  project_id  = data.google_project.project.project_id
+  type        = "private"
 
-  private_visibility_config {
-    networks {
-      network_url = module.fedlearn-vpc.network_id
-    }
-  }
+  private_visibility_config_networks = [
+    module.fedlearn-vpc.network_id
+  ]
+
+  recordsets = [
+    {
+      name = "*.googleapis.com."
+      type = "CNAME"
+      ttl  = 300
+      records = [
+        "private.googleapis.com.",
+      ]
+    },
+    {
+      name    = "private.googleapis.com."
+      type    = "A"
+      ttl     = 300
+      records = local.private_google_access_ips
+    },
+  ]
 }
 
-resource "google_dns_record_set" "private-google-apis-cname" {
-  managed_zone = google_dns_managed_zone.private-google-apis.name
-  name         = "*.googleapis.com."
-  type         = "CNAME"
-  rrdatas      = ["private.googleapis.com."]
-  ttl          = 300
-}
+module "cloud-dns-private-container-registry" {
+  source  = "terraform-google-modules/cloud-dns/google"
+  version = "5.0.0"
 
-resource "google_dns_record_set" "private-google-apis-a" {
-  managed_zone = google_dns_managed_zone.private-google-apis.name
-  name         = "private.googleapis.com."
-  type         = "A"
-  rrdatas      = local.private_google_access_ips
-  ttl          = 300
-}
-
-
-
-resource "google_dns_managed_zone" "private-container-registry" {
-  name        = "private-container-registry"
-  dns_name    = "gcr.io."
   description = "Private DNS zone for Container Registry"
-  visibility  = "private"
+  domain      = "gcr.io."
+  name        = "private-container-registry"
+  project_id  = data.google_project.project.project_id
+  type        = "private"
 
-  private_visibility_config {
-    networks {
-      network_url = module.fedlearn-vpc.network_id
-    }
-  }
+  private_visibility_config_networks = [
+    module.fedlearn-vpc.network_id
+  ]
+
+  recordsets = [
+    {
+      name = "*.gcr.io."
+      type = "CNAME"
+      ttl  = 300
+      records = [
+        "gcr.io.",
+      ]
+    },
+    {
+      name    = "gcr.io."
+      type    = "A"
+      ttl     = 300
+      records = local.private_google_access_ips
+    },
+  ]
 }
 
-resource "google_dns_record_set" "private-container-registry-cname" {
-  managed_zone = google_dns_managed_zone.private-container-registry.name
-  name         = "*.gcr.io."
-  type         = "CNAME"
-  rrdatas      = ["gcr.io."]
-  ttl          = 300
-}
+module "cloud-dns-private-artifact-registry" {
+  source  = "terraform-google-modules/cloud-dns/google"
+  version = "5.0.0"
 
-resource "google_dns_record_set" "private-container-registry-a" {
-  managed_zone = google_dns_managed_zone.private-container-registry.name
-  name         = "gcr.io."
-  type         = "A"
-  rrdatas      = local.private_google_access_ips
-  ttl          = 300
-}
-
-
-
-resource "google_dns_managed_zone" "private-artifact-registry" {
-  name        = "private-artifact-registry"
-  dns_name    = "pkg.dev."
   description = "Private DNS zone for Artifact Registry"
-  visibility  = "private"
+  domain      = "pkg.dev."
+  name        = "private-artifact-registry"
+  project_id  = data.google_project.project.project_id
+  type        = "private"
 
-  private_visibility_config {
-    networks {
-      network_url = module.fedlearn-vpc.network_id
-    }
-  }
-}
+  private_visibility_config_networks = [
+    module.fedlearn-vpc.network_id
+  ]
 
-resource "google_dns_record_set" "private-artifact-registry-cname" {
-  managed_zone = google_dns_managed_zone.private-artifact-registry.name
-  name         = "*.pkg.dev."
-  type         = "CNAME"
-  rrdatas      = ["pkg.dev."]
-  ttl          = 300
-}
-
-resource "google_dns_record_set" "private-artifact-registry-a" {
-  managed_zone = google_dns_managed_zone.private-artifact-registry.name
-  name         = "pkg.dev."
-  type         = "A"
-  rrdatas      = local.private_google_access_ips
-  ttl          = 300
+  recordsets = [
+    {
+      name = "*.pkg.dev."
+      type = "CNAME"
+      ttl  = 300
+      records = [
+        "pkg.dev.",
+      ]
+    },
+    {
+      name    = "pkg.dev."
+      type    = "A"
+      ttl     = 300
+      records = local.private_google_access_ips
+    },
+  ]
 }


### PR DESCRIPTION
This PR refactors the DNS configuration to use the [Cloud DNS Terraform module](https://registry.terraform.io/modules/terraform-google-modules/cloud-dns/google/latest).