### PR TITLE
Use the Service Account Terraform module to provision service accounts

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,36 +1,16 @@
-# Service Account used by the nodes in a tenant node pool
-resource "google_service_account" "tenant_nodepool_sa" {
-  for_each     = local.tenants
-  project      = data.google_project.project.project_id
-  account_id   = each.value.tenant_nodepool_sa_name
-  display_name = "Service account for ${each.key} node pool in cluster ${var.cluster_name}"
+module "service_accounts" {
+  source     = "terraform-google-modules/service-accounts/google"
+  version    = "4.2.1"
+  project_id = data.google_project.project.project_id
+
+  grant_billing_role = false
+  grant_xpn_roles    = false
+  names              = local.list_sa_names
 
   depends_on = [
     module.project-services
   ]
-}
 
-# Service Account used by the nodes in the main node pool
-resource "google_service_account" "main_nodepool_sa" {
-  project      = data.google_project.project.project_id
-  account_id   = local.main_node_pool_sa_name
-  display_name = "Service account for ${local.main_node_pool_name} node pool in cluster ${var.cluster_name}"
-
-  depends_on = [
-    module.project-services
-  ]
-}
-
-# Service Account used by apps in a tenant namespace
-resource "google_service_account" "tenant_apps_sa" {
-  for_each     = local.tenants
-  project      = data.google_project.project.project_id
-  account_id   = each.value.tenant_apps_sa_name
-  display_name = "Service account for ${each.key} apps in cluster ${var.cluster_name}"
-
-  depends_on = [
-    module.project-services
-  ]
 }
 
 # default roles for the node SAs

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -36,8 +36,8 @@ module "project-iam-bindings" {
 
 # enable the tenant apps service accounts for Workload Identity
 resource "google_service_account_iam_binding" "workload_identity" {
-  for_each           = module.service_accounts.service_accounts_map
-  service_account_id = each.value.name
+  for_each           = local.tenants
+  service_account_id = module.service_accounts.service_accounts_map[each.value.tenant_apps_sa_name].name
   role               = "roles/iam.workloadIdentityUser"
 
   members = [

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -10,7 +10,6 @@ module "service_accounts" {
   depends_on = [
     module.project-services
   ]
-
 }
 
 # default roles for the node SAs
@@ -21,28 +20,13 @@ module "project-iam-bindings" {
   mode     = "authoritative"
 
   bindings = {
-    # Least-privilege roles needed for a node pool service account to function
-    "roles/logging.logWriter" = concat(
-      [for service_account in google_service_account.tenant_nodepool_sa : format("serviceAccount:%s", service_account.email)],
-      [format("serviceAccount:%s", google_service_account.main_nodepool_sa.email)]
-    )
-    "roles/monitoring.metricWriter" = concat(
-      [for service_account in google_service_account.tenant_nodepool_sa : format("serviceAccount:%s", service_account.email)],
-      [format("serviceAccount:%s", google_service_account.main_nodepool_sa.email)]
-    )
-    "roles/monitoring.viewer" = concat(
-      [for service_account in google_service_account.tenant_nodepool_sa : format("serviceAccount:%s", service_account.email)],
-      [format("serviceAccount:%s", google_service_account.main_nodepool_sa.email)]
-    )
-    "roles/stackdriver.resourceMetadata.writer" = concat(
-      [for service_account in google_service_account.tenant_nodepool_sa : format("serviceAccount:%s", service_account.email)],
-      [format("serviceAccount:%s", google_service_account.main_nodepool_sa.email)]
-    )
-    # Grant node pool service accounts read access to Container Registry and Artifact Registry
-    "roles/artifactregistry.reader" = concat(
-      [for service_account in google_service_account.tenant_nodepool_sa : format("serviceAccount:%s", service_account.email)],
-      [format("serviceAccount:%s", google_service_account.main_nodepool_sa.email)]
-    )
+    # Least-privilege roles needed for a node pool service account to function and
+    # to get read-only access to Container Registry and Artifact Registry
+    "roles/logging.logWriter"                   = local.list_nodepool_sa_iam_emails,
+    "roles/monitoring.metricWriter"             = local.list_nodepool_sa_iam_emails,
+    "roles/monitoring.viewer"                   = local.list_nodepool_sa_iam_emails,
+    "roles/stackdriver.resourceMetadata.writer" = local.list_nodepool_sa_iam_emails,
+    "roles/artifactregistry.reader"             = local.list_nodepool_sa_iam_emails,
   }
 
   depends_on = [

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -36,7 +36,7 @@ module "project-iam-bindings" {
 
 # enable the tenant apps service accounts for Workload Identity
 resource "google_service_account_iam_binding" "workload_identity" {
-  for_each           = google_service_account.tenant_apps_sa
+  for_each           = module.service_accounts.service_accounts_map
   service_account_id = each.value.name
   role               = "roles/iam.workloadIdentityUser"
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -145,12 +145,10 @@ locals {
     ["serviceAccount:${module.service_accounts.service_accounts_map[local.main_node_pool_sa_name].email}"],
   )
 
-  list_apps_sa_names = [for tenant in local.tenants : tenant.tenant_apps_sa_name]
-
   list_sa_names = concat(
     [local.main_node_pool_sa_name],
     [for tenant in local.tenants : tenant.tenant_nodepool_sa_name],
-    local.list_apps_sa_names,
+    [for tenant in local.tenants : tenant.tenant_apps_sa_name],
   )
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -132,10 +132,15 @@ locals {
   }
   gke_robot_sa = "service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 
-  # list of service account emails used by the tenant node pools and the main node pool
+
+  list_nodepool_sa_emails = concat(
+    [for tenant in local.tenants : module.service_accounts.emails[tenant.tenant_nodepool_sa_name]],
+    [module.service_accounts.emails[local.main_node_pool_sa_name]]
+  )
+
   list_nodepool_sa_iam_emails = concat(
     [for tenant in local.tenants : module.service_accounts.iam_emails[tenant.tenant_nodepool_sa_name]],
-    [module.service_accounts.iam_emails[main_node_pool_sa_name]]
+    [module.service_accounts.iam_emails[local.main_node_pool_sa_name]]
   )
 
   list_sa_names = concat(

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -131,15 +131,18 @@ locals {
   }
   gke_robot_sa = "service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 
-
+  # We can't use module.service_accounts.emails because of
+  # https://github.com/terraform-google-modules/terraform-google-service-accounts/issues/59
   list_nodepool_sa_emails = concat(
-    [for tenant in local.tenants : module.service_accounts.emails[tenant.tenant_nodepool_sa_name]],
-    [module.service_accounts.emails[local.main_node_pool_sa_name]]
+    [for tenant in local.tenants : module.service_accounts.service_accounts_map[tenant.tenant_nodepool_sa_name].email],
+    [module.service_accounts.service_accounts_map[local.main_node_pool_sa_name].email]
   )
 
+  # We can't use module.service_accounts.iam_emails because of
+  # https://github.com/terraform-google-modules/terraform-google-service-accounts/issues/59
   list_nodepool_sa_iam_emails = concat(
-    [for tenant in local.tenants : module.service_accounts.iam_emails[tenant.tenant_nodepool_sa_name]],
-    [module.service_accounts.iam_emails[local.main_node_pool_sa_name]]
+    [for tenant in local.tenants : "serviceAccount:${module.service_accounts.service_accounts_map[tenant.tenant_nodepool_sa_name].email}"],
+    "serviceAccount:${module.service_accounts.service_accounts_map[local.main_node_pool_sa_name].email}",
   )
 
   list_apps_sa_names = [for tenant in local.tenants : tenant.tenant_apps_sa_name]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -133,9 +133,9 @@ locals {
   gke_robot_sa = "service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 
   # list of service account emails used by the tenant node pools and the main node pool
-  list_nodepool_sa_emails = concat(
-    [for sa in google_service_account.tenant_nodepool_sa : sa.email],
-    [google_service_account.main_nodepool_sa.email]
+  list_nodepool_sa_iam_emails = concat(
+    [for tenant in local.tenants : module.service_accounts.iam_emails[tenant.tenant_nodepool_sa_name]],
+    [module.service_accounts.iam_emails[main_node_pool_sa_name]]
   )
 
   list_sa_names = concat(

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -113,8 +113,7 @@ module "gke" {
     module.fedlearn-vpc,
     module.project-iam-bindings,
     module.project-services,
-    google_service_account.main_nodepool_sa,
-    google_service_account.tenant_nodepool_sa,
+    module.service_accounts,
   ]
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -132,10 +132,16 @@ locals {
   }
   gke_robot_sa = "service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 
-  # list of dedicated service accounts used by the tenant node pools and the main node pool
-  list_nodepool_sa = concat(
+  # list of service account emails used by the tenant node pools and the main node pool
+  list_nodepool_sa_emails = concat(
     [for sa in google_service_account.tenant_nodepool_sa : sa.email],
     [google_service_account.main_nodepool_sa.email]
+  )
+
+  list_sa_names = concat(
+    [local.main_node_pool_sa_name],
+    [for tenant in local.tenants : tenant.tenant_nodepool_sa_name],
+    [for tenant in local.tenants : tenant.tenant_apps_sa_name],
   )
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -142,10 +142,12 @@ locals {
     [module.service_accounts.iam_emails[local.main_node_pool_sa_name]]
   )
 
+  list_apps_sa_names = [for tenant in local.tenants : tenant.tenant_apps_sa_name]
+
   list_sa_names = concat(
     [local.main_node_pool_sa_name],
     [for tenant in local.tenants : tenant.tenant_nodepool_sa_name],
-    [for tenant in local.tenants : tenant.tenant_apps_sa_name],
+    local.list_apps_sa_names,
   )
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -142,7 +142,7 @@ locals {
   # https://github.com/terraform-google-modules/terraform-google-service-accounts/issues/59
   list_nodepool_sa_iam_emails = concat(
     [for tenant in local.tenants : "serviceAccount:${module.service_accounts.service_accounts_map[tenant.tenant_nodepool_sa_name].email}"],
-    "serviceAccount:${module.service_accounts.service_accounts_map[local.main_node_pool_sa_name].email}",
+    ["serviceAccount:${module.service_accounts.service_accounts_map[local.main_node_pool_sa_name].email}"],
   )
 
   list_apps_sa_names = [for tenant in local.tenants : tenant.tenant_apps_sa_name]

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -20,7 +20,7 @@ module "fedlearn-vpc" {
       direction               = "EGRESS"
       name                    = "node-pools-deny-egress"
       priority                = 65535
-      target_service_accounts = local.list_nodepool_sa
+      target_service_accounts = local.list_nodepool_sa_emails
 
       deny = [
         {
@@ -34,7 +34,7 @@ module "fedlearn-vpc" {
       name                    = "node-pools-allow-egress-nodes-pods-services"
       priority                = 1000
       ranges                  = [module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].ip_cidr_range, local.fedlearn_pods_ip_range, local.fedlearn_services_ip_range]
-      target_service_accounts = local.list_nodepool_sa
+      target_service_accounts = local.list_nodepool_sa_emails
 
       allow = [
         {
@@ -48,7 +48,7 @@ module "fedlearn-vpc" {
       direction               = "EGRESS"
       name                    = "node-pools-allow-egress-api-server"
       priority                = 1000
-      target_service_accounts = local.list_nodepool_sa
+      target_service_accounts = local.list_nodepool_sa_emails
 
       allow = [
         {
@@ -63,7 +63,7 @@ module "fedlearn-vpc" {
       direction               = "EGRESS"
       name                    = "node-pools-allow-egress-google-apis"
       priority                = 1000
-      target_service_accounts = local.list_nodepool_sa
+      target_service_accounts = local.list_nodepool_sa_emails
 
       allow = [
         {


### PR DESCRIPTION
This PR refactors provisioning to use the Service Account Terraform module instead of directly using resources.