### PR TITLE
Don't taint the main node pool and don't create the default node pool service account

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -81,7 +81,7 @@ module "gke" {
       key    = "tenant"
       value  = tenant_name
       effect = "NO_EXECUTE"
-    }]
+    }] if tenant_name != local.main_tenant_name
   }
 
   depends_on = [

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,6 +16,7 @@ module "gke" {
 
   add_cluster_firewall_rules   = true
   authenticator_security_group = var.gke_rbac_security_group_domain != null ? "gke-security-groups@${var.gke_rbac_security_group_domain}" : null
+  create_service_account       = false
   datapath_provider            = "ADVANCED_DATAPATH"
   enable_binary_authorization  = true
   enable_private_endpoint      = false


### PR DESCRIPTION
This PR does the following:

- Don't add taints to the `main` node pool so that system workloads can run there.
- Don't create the default node pool service account because we don't need the default node pool, and it also pollutes the Terraform state by reporting unnecessary changes.