### PR TITLE
Add labels to tenant node pools only

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -82,6 +82,17 @@ module "gke" {
       key    = "tenant"
       value  = tenant_name
       effect = "NO_EXECUTE"
+      },
+      {
+        # When GKE Sandbox is enabled, it adds the following taint automatically.
+        # Ref: https://cloud.google.com/kubernetes-engine/docs/how-to/sandbox-pods#regular-pod
+        # We add it using Terraform because Terraform reports it missing after the
+        # node pool is created, and it would cause the recreation of the node pool
+        # because Terraform would try to remove the taint because it's not aware
+        # of it.
+        key    = "sandbox.gke.io/runtime"
+        value  = "gvisor"
+        effect = "NO_SCHEDULE"
     }] if tenant_name != local.main_tenant_name
   }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -84,17 +84,6 @@ module "gke" {
       key    = "tenant"
       value  = tenant_name
       effect = "NO_EXECUTE"
-      },
-      {
-        # When GKE Sandbox is enabled, it adds the following taint automatically.
-        # Ref: https://cloud.google.com/kubernetes-engine/docs/how-to/sandbox-pods#regular-pod
-        # We add it using Terraform because Terraform reports it missing after the
-        # node pool is created, and it would cause the recreation of the node pool
-        # because Terraform would try to remove the taint because it's not aware
-        # of it.
-        key    = "sandbox.gke.io/runtime"
-        value  = "gvisor"
-        effect = "NO_SCHEDULE"
     }] if tenant_name != local.main_tenant_name
   }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -74,8 +74,7 @@ module "gke" {
   # Add a label with tenant name to each tenant nodepool
   node_pools_labels = {
     for tenant_name, config in local.tenants : config.tenant_nodepool_name => {
-      "tenant"                 = tenant_name,
-      "sandbox.gke.io/runtime" = "gvisor"
+      "tenant" = tenant_name
     } if tenant_name != local.main_tenant_name
   }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -73,7 +73,10 @@ module "gke" {
 
   # Add a label with tenant name to each tenant nodepool
   node_pools_labels = {
-    for tenant_name, config in local.tenants : config.tenant_nodepool_name => { "tenant" = tenant_name }
+    for tenant_name, config in local.tenants : config.tenant_nodepool_name => {
+      "tenant"                 = tenant_name,
+      "sandbox.gke.io/runtime" = "gvisor"
+    } if tenant_name != local.main_tenant_name
   }
 
   # Add a taint based on the tenant name to each tenant nodepool


### PR DESCRIPTION
This PR does the following:

- Configure GKE Sandbox taints and labels so that Terraform doesn't try to delete stuff that GKE automatically adds, causing node pool replacement.