### PR TITLE
Use the workload identity module

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -41,9 +41,9 @@ module "fl-workload-identity" {
   project_id = data.google_project.project.project_id
 
   annotate_k8s_sa     = false
-  gcp_sa_name         = module.service_accounts.service_accounts_map[each.value.tenant_apps_sa_name].name
   k8s_sa_name         = "ksa"
   location            = module.gke.location
+  name                = module.service_accounts.service_accounts_map[each.value.tenant_apps_sa_name].name
   namespace           = each.key
   use_existing_gcp_sa = true
   use_existing_k8s_sa = true

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -34,21 +34,6 @@ module "project-iam-bindings" {
   ]
 }
 
-# enable the tenant apps service accounts for Workload Identity
-resource "google_service_account_iam_binding" "workload_identity" {
-  for_each           = local.tenants
-  service_account_id = module.service_accounts.service_accounts_map[each.value.tenant_apps_sa_name].name
-  role               = "roles/iam.workloadIdentityUser"
-
-  members = [
-    format("serviceAccount:%s.svc.id.goog[%s/ksa]", data.google_project.project.project_id, each.key),
-  ]
-  # workload identity pool must exist before binding
-  depends_on = [
-    module.gke
-  ]
-}
-
 module "fl-workload-identity" {
   for_each   = local.tenants
   source     = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -48,3 +48,24 @@ resource "google_service_account_iam_binding" "workload_identity" {
     module.gke
   ]
 }
+
+module "fl-workload-identity" {
+  for_each   = local.tenants
+  source     = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
+  version    = "26.1.1"
+  project_id = data.google_project.project.project_id
+
+  annotate_k8s_sa     = false
+  gcp_sa_name         = module.service_accounts.service_accounts_map[each.value.tenant_apps_sa_name].name
+  k8s_sa_name         = "ksa"
+  location            = module.gke.location
+  namespace           = each.key
+  use_existing_gcp_sa = true
+  use_existing_k8s_sa = true
+
+  # The workload identity pool must exist before binding
+  module_depends_on = [
+    module.gke
+  ]
+
+}


### PR DESCRIPTION
This PR refactors the Workload Identity configuration to use a module instead of simpler Terraform resources.