### PR TITLE
Add missing license headers and move GKE and providers to dedicated files

### DIFF
--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # See the series of blog posts for details on enabling Anthos Config Management using Terraform
 # https://cloud.google.com/blog/topics/anthos/using-terraform-to-enable-config-sync-on-a-gke-cluster
 

--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module "asm" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/asm"
   version = "26.1.1"

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 locals {
   # See https://cloud.google.com/vpc/docs/configure-private-google-access#config-domain
   private_google_access_ips = [

--- a/terraform/gke.tf
+++ b/terraform/gke.tf
@@ -1,0 +1,110 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module "gke" {
+  # The beta-private-cluster module enables beta GKE features and set opinionated defaults.
+  # See the module docs https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/master/modules/beta-private-cluster
+  #
+  # The following configuration creates a cluster that implements many of the recommendations in the GKE hardening guide
+  # https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster:
+  #  - private GKE cluster with authorized networks
+  #  - at least 2 node pools (one default pool, plus one per tenant)
+  #  - workload identity
+  #  - shielded nodes
+  #  - GKE sandbox (gVisor) for the tenant nodes
+  #  - Dataplane V2 (which automatically enables network policy)
+  #  - secrets encryption
+  source  = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
+  version = "26.1.1"
+
+  add_cluster_firewall_rules   = true
+  authenticator_security_group = var.gke_rbac_security_group_domain != null ? "gke-security-groups@${var.gke_rbac_security_group_domain}" : null
+  create_service_account       = false
+  datapath_provider            = "ADVANCED_DATAPATH"
+  enable_binary_authorization  = true
+  enable_private_endpoint      = false
+  enable_private_nodes         = true
+  enable_shielded_nodes        = true
+  grant_registry_access        = true
+  http_load_balancing          = false
+  ip_range_pods                = "pods"
+  ip_range_services            = "services"
+  master_global_access_enabled = true
+  master_ipv4_cidr_block       = var.master_ipv4_cidr_block
+  name                         = var.cluster_name
+  network                      = module.fedlearn-vpc.network_name
+  network_policy               = false # automatically enabled with Dataplane V2
+  project_id                   = data.google_project.project.project_id
+  region                       = var.region
+  regional                     = var.cluster_regional
+  release_channel              = var.cluster_gke_release_channel
+  remove_default_node_pool     = true
+  subnetwork                   = module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].name
+  zones                        = var.zones
+
+
+  # Encrypt cluster secrets at the application layer
+  database_encryption = [{
+    "key_name" : module.kms.keys[var.cluster_secrets_keyname],
+    "state" : "ENCRYPTED"
+  }]
+
+  master_authorized_networks = [
+    {
+      display_name : "NAT IP",
+      cidr_block : format("%s/32", google_compute_address.nat_ip.address)
+    },
+    # Add the local IP of the workstation that applies the Terraform to authorized networks
+    {
+      display_name : "Local IP",
+      cidr_block : "${chomp(data.http.installation_workstation_ip.body)}/32"
+    }
+  ]
+
+  node_pools = [for tenant_name, config in local.tenants : {
+    auto_upgrade                = true
+    enable_integrity_monitoring = true
+    enable_secure_boot          = true
+    image_type                  = "COS_CONTAINERD"
+    machine_type                = tenant_name == local.main_tenant_name ? var.cluster_default_pool_machine_type : var.cluster_tenant_pool_machine_type
+    max_count                   = tenant_name == local.main_tenant_name ? var.cluster_default_pool_max_nodes : var.cluster_tenant_pool_max_nodes
+    min_count                   = tenant_name == local.main_tenant_name ? var.cluster_default_pool_min_nodes : var.cluster_tenant_pool_min_nodes
+    name                        = config.tenant_nodepool_name
+    sandbox_enabled             = tenant_name == local.main_tenant_name ? false : true
+    service_account             = format("%s@%s.iam.gserviceaccount.com", config.tenant_nodepool_sa_name, data.google_project.project.project_id)
+  }]
+
+  # Add a label with tenant name to each tenant nodepool
+  node_pools_labels = {
+    for tenant_name, config in local.tenants : config.tenant_nodepool_name => {
+      "tenant" = tenant_name
+    } if tenant_name != local.main_tenant_name
+  }
+
+  # Add a taint based on the tenant name to each tenant nodepool
+  node_pools_taints = {
+    for tenant_name, config in local.tenants : config.tenant_nodepool_name => [{
+      key    = "tenant"
+      value  = tenant_name
+      effect = "NO_EXECUTE"
+    }] if tenant_name != local.main_tenant_name
+  }
+
+  depends_on = [
+    module.fedlearn-vpc,
+    module.project-iam-bindings,
+    module.project-services,
+    module.service_accounts,
+  ]
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module "service_accounts" {
   source     = "terraform-google-modules/service-accounts/google"
   version    = "4.2.1"

--- a/terraform/kms.tf
+++ b/terraform/kms.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module "kms" {
   source  = "terraform-google-modules/kms/google"
   version = "2.2.2"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,99 +1,16 @@
-module "gke" {
-  # The beta-private-cluster module enables beta GKE features and set opinionated defaults.
-  # See the module docs https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/master/modules/beta-private-cluster
-  #
-  # The following configuration creates a cluster that implements many of the recommendations in the GKE hardening guide
-  # https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster:
-  #  - private GKE cluster with authorized networks
-  #  - at least 2 node pools (one default pool, plus one per tenant)
-  #  - workload identity
-  #  - shielded nodes
-  #  - GKE sandbox (gVisor) for the tenant nodes
-  #  - Dataplane V2 (which automatically enables network policy)
-  #  - secrets encryption
-  source  = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
-  version = "26.1.1"
-
-  add_cluster_firewall_rules   = true
-  authenticator_security_group = var.gke_rbac_security_group_domain != null ? "gke-security-groups@${var.gke_rbac_security_group_domain}" : null
-  create_service_account       = false
-  datapath_provider            = "ADVANCED_DATAPATH"
-  enable_binary_authorization  = true
-  enable_private_endpoint      = false
-  enable_private_nodes         = true
-  enable_shielded_nodes        = true
-  grant_registry_access        = true
-  http_load_balancing          = false
-  ip_range_pods                = "pods"
-  ip_range_services            = "services"
-  master_global_access_enabled = true
-  master_ipv4_cidr_block       = var.master_ipv4_cidr_block
-  name                         = var.cluster_name
-  network                      = module.fedlearn-vpc.network_name
-  network_policy               = false # automatically enabled with Dataplane V2
-  project_id                   = data.google_project.project.project_id
-  region                       = var.region
-  regional                     = var.cluster_regional
-  release_channel              = var.cluster_gke_release_channel
-  remove_default_node_pool     = true
-  subnetwork                   = module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].name
-  zones                        = var.zones
-
-
-  # Encrypt cluster secrets at the application layer
-  database_encryption = [{
-    "key_name" : module.kms.keys[var.cluster_secrets_keyname],
-    "state" : "ENCRYPTED"
-  }]
-
-  master_authorized_networks = [
-    {
-      display_name : "NAT IP",
-      cidr_block : format("%s/32", google_compute_address.nat_ip.address)
-    },
-    # Add the local IP of the workstation that applies the Terraform to authorized networks
-    {
-      display_name : "Local IP",
-      cidr_block : "${chomp(data.http.installation_workstation_ip.body)}/32"
-    }
-  ]
-
-  node_pools = [for tenant_name, config in local.tenants : {
-    auto_upgrade                = true
-    enable_integrity_monitoring = true
-    enable_secure_boot          = true
-    image_type                  = "COS_CONTAINERD"
-    machine_type                = tenant_name == local.main_tenant_name ? var.cluster_default_pool_machine_type : var.cluster_tenant_pool_machine_type
-    max_count                   = tenant_name == local.main_tenant_name ? var.cluster_default_pool_max_nodes : var.cluster_tenant_pool_max_nodes
-    min_count                   = tenant_name == local.main_tenant_name ? var.cluster_default_pool_min_nodes : var.cluster_tenant_pool_min_nodes
-    name                        = config.tenant_nodepool_name
-    sandbox_enabled             = tenant_name == local.main_tenant_name ? false : true
-    service_account             = format("%s@%s.iam.gserviceaccount.com", config.tenant_nodepool_sa_name, data.google_project.project.project_id)
-  }]
-
-  # Add a label with tenant name to each tenant nodepool
-  node_pools_labels = {
-    for tenant_name, config in local.tenants : config.tenant_nodepool_name => {
-      "tenant" = tenant_name
-    } if tenant_name != local.main_tenant_name
-  }
-
-  # Add a taint based on the tenant name to each tenant nodepool
-  node_pools_taints = {
-    for tenant_name, config in local.tenants : config.tenant_nodepool_name => [{
-      key    = "tenant"
-      value  = tenant_name
-      effect = "NO_EXECUTE"
-    }] if tenant_name != local.main_tenant_name
-  }
-
-  depends_on = [
-    module.fedlearn-vpc,
-    module.project-iam-bindings,
-    module.project-services,
-    module.service_accounts,
-  ]
-}
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 locals {
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -54,9 +54,3 @@ data "google_project" "project" {
 }
 
 data "google_client_config" "default" {}
-
-provider "kubernetes" {
-  host                   = "https://${module.gke.endpoint}"
-  token                  = data.google_client_config.default.access_token
-  cluster_ca_certificate = base64decode(module.gke.ca_certificate)
-}

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 locals {
   fedlearn_subnet_name = "subnet-01"
   fedlearn_subnet_key  = "${var.region}/${local.fedlearn_subnet_name}"

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -12,28 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-terraform {
-  required_version = ">=1.0"
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = ">= 4.20.0, <5.0.0"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = ">= 4.20.0, <5.0.0"
-    }
-    http = {
-      source  = "hashicorp/http"
-      version = ">= 2.2.0, < 4.0.0"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.0, ~> 2.10"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 3.3.1, <4.0.0"
-    }
-  }
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+
+provider "kubernetes" {
+  host                   = "https://${module.gke.endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module "project-services-cloud-resource-manager" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
   version = "14.2.0"

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,2 +1,16 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Uncomment the following variable and set its value to point to your own Google Cloud project id
 # project_id = ""

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The Google Cloud project ID"
   type        = string

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_version = ">=1.0"
   required_providers {


### PR DESCRIPTION
This PR does the following:

- Add missing license headers to Terraform files.
- Move GKE and provider config to dedicated files.