### PR TITLE
Accept ingress from external clients to workers

### DIFF
--- a/examples/federated-learning/tff/distributed-fl-simulation-k8s/distributed-fl-workload-pkg/service-mesh-worker-ingress-gateway.yaml
+++ b/examples/federated-learning/tff/distributed-fl-simulation-k8s/distributed-fl-workload-pkg/service-mesh-worker-ingress-gateway.yaml
@@ -1,0 +1,32 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: tff-worker-ingress-gateway
+  namespace: ns  # kpt-set: ${namespace}
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - istio-ingress/ingress-gateway
+  http:
+    - route:
+        - destination:
+            host: tff-worker.ns.svc.cluster.local  # kpt-set: tff-worker.${namespace}.svc.cluster.local
+            port:
+              number: 8000
+...

--- a/examples/federated-learning/tff/distributed-fl-simulation-k8s/mesh-wide/ingress-gateway.yaml
+++ b/examples/federated-learning/tff/distributed-fl-simulation-k8s/mesh-wide/ingress-gateway.yaml
@@ -169,7 +169,7 @@ metadata:
 spec:
   selector:
     istio: ingressgateway
-  # Restrict the following items to tenant namespaces only if needed
+  # Restrict the following items to tenant namespaces only, as needed
   # Ref: https://istio.io/latest/docs/reference/config/networking/gateway/#Server
   servers:
     - port:
@@ -306,4 +306,21 @@ spec:
     - to:
         - ipBlock:
             cidr: 199.36.153.8/30
+...
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-distributed-tff-example-ports
+  namespace: istio-ingress
+spec:
+  podSelector:
+    matchLabels:
+      istio: ingress
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8000
 ...

--- a/examples/federated-learning/tff/distributed-fl-simulation-k8s/mesh-wide/ingress-gateway.yaml
+++ b/examples/federated-learning/tff/distributed-fl-simulation-k8s/mesh-wide/ingress-gateway.yaml
@@ -316,7 +316,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      istio: ingress
+      istio: ingressgateway
   policyTypes:
     - Ingress
   ingress:

--- a/examples/federated-learning/tff/distributed-fl-simulation-k8s/mesh-wide/ingress-gateway.yaml
+++ b/examples/federated-learning/tff/distributed-fl-simulation-k8s/mesh-wide/ingress-gateway.yaml
@@ -141,7 +141,7 @@ metadata:
     istio: ingressgateway
 spec:
   ports:
-    # status-port exposes a /healthz/ready endpoint that can be used with GKE Ingress health checks
+    # status-port exposes a /healthz/ready endpoint that can be used with GKE health checks
     - name: status-port
       port: 15021
       protocol: TCP
@@ -169,6 +169,8 @@ metadata:
 spec:
   selector:
     istio: ingressgateway
+  # Restrict the following items to tenant namespaces only if needed
+  # Ref: https://istio.io/latest/docs/reference/config/networking/gateway/#Server
   servers:
     - port:
         number: 8000

--- a/examples/federated-learning/tff/distributed-fl-simulation-k8s/mesh-wide/ingress-gateway.yaml
+++ b/examples/federated-learning/tff/distributed-fl-simulation-k8s/mesh-wide/ingress-gateway.yaml
@@ -342,3 +342,22 @@ spec:
     8000:
       mode: DISABLE
 ...
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-ingress-to-distributed-tff-example-ports
+  namespace: istio-ingress
+spec:
+  action: ALLOW
+  selector:
+    matchLabels:
+      istio: ingressgateway
+  rules:
+    - to:
+        - operation:
+            # methods:
+            #   - POST
+            ports:
+              - "8000"
+...

--- a/examples/federated-learning/tff/distributed-fl-simulation-k8s/mesh-wide/ingress-gateway.yaml
+++ b/examples/federated-learning/tff/distributed-fl-simulation-k8s/mesh-wide/ingress-gateway.yaml
@@ -356,8 +356,10 @@ spec:
   rules:
     - to:
         - operation:
-            # methods:
-            #   - POST
+            # For gRPC it's always POST
+            # Ref: https://istio.io/latest/docs/reference/config/security/authorization-policy/#Operation
+            methods:
+              - POST
             ports:
               - "8000"
 ...

--- a/examples/federated-learning/tff/distributed-fl-simulation-k8s/mesh-wide/ingress-gateway.yaml
+++ b/examples/federated-learning/tff/distributed-fl-simulation-k8s/mesh-wide/ingress-gateway.yaml
@@ -324,3 +324,21 @@ spec:
         - protocol: TCP
           port: 8000
 ...
+---
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: istio-ingress
+spec:
+  selector:
+    matchLabels:
+      istio: ingressgateway
+  # Inherit mTLS mode from mesh- or namespace-wide settings
+  mtls:
+    mode: UNSET
+  # Overwrite settings for the distributed TensorFlow Federated port
+  portLevelMtls:
+    8000:
+      mode: DISABLE
+...

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,6 +45,9 @@ locals {
   distributed_tff_example_is_there_a_coordinator_flags = [for tenant in local.tenants : tenant.distributed_tff_example_is_coordinator]
   distributed_tff_example_is_there_a_coordinator       = anytrue(local.distributed_tff_example_is_there_a_coordinator_flags) # Useful to know if we deployed a coordinator for the distributed TensorFlow Federated example in any namespace
 
+  # If the coordinator namespace is set to istio-ingress, we assume that workers are outside the service mesh (example: in another cluster)
+  distributed_tff_example_are_workers_outside_the_coordinator_mesh = var.distributed_tff_example_coordinator_namespace == "istio-ingress" ? true : false
+
   tenant_apps_kubernetes_service_account_name = "ksa"
 
   tenants_excluding_main = { for k, v in local.tenants : k => v if k != local.main_tenant_name }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -135,7 +135,7 @@ locals {
   ditributed_tff_example_container_image_repository_hostname    = "${google_artifact_registry_repository.container_image_repository.location}-docker.pkg.dev"
   distributed_tff_example_container_image_repository_id         = "${local.ditributed_tff_example_container_image_repository_hostname}/${google_artifact_registry_repository.container_image_repository.project}/${google_artifact_registry_repository.container_image_repository.repository_id}"
   distributed_tff_example_localized_untagged_container_image_id = "${local.distributed_tff_example_container_image_repository_id}/tff-runtime"
-  distributed_tff_example_localized_container_image_id          = "${local.distributed_tff_example_localized_untagged_container_image_id}:${data.external.blueprint_repository_head_commit_hash.result.sha}"
+  distributed_tff_example_localized_container_image_id          = "${local.distributed_tff_example_localized_untagged_container_image_id}:${local.distributed_tff_example_container_image_source_descriptors_content_hash}"
 
   # Temporary placeholder
   tenant_developer_example_account = "someuser@example.com"

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -170,3 +170,29 @@ module "cloud_router" {
 data "http" "installation_workstation_ip" {
   url = "http://ipv4.icanhazip.com"
 }
+
+module "distributed_tff_example_firewall_rules" {
+  count = var.distributed_tff_example_deploy_ingress_gateway ? 1 : 0
+
+  source  = "terraform-google-modules/network/google//modules/firewall-rules"
+  version = "7.2.0"
+
+  project_id   = data.google_project.project.project_id
+  network_name = module.fedlearn-vpc.network_name
+
+  ingress_rules = [{
+    name                    = "allow-distributed-tff-example-grpc-ingress"
+    description             = "Allow ingress to the gRPC port for the distributed TensorFlow Federated example"
+    destination_ranges      = [module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].ip_cidr_range, local.fedlearn_pods_ip_range, local.fedlearn_services_ip_range]
+    target_service_accounts = local.list_nodepool_sa_emails
+
+    allow = [{
+      protocol = "tcp"
+      ports    = ["8000"]
+    }]
+
+    log_config = {
+      metadata = "INCLUDE_ALL_METADATA"
+    }
+  }]
+}

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -164,3 +164,9 @@ module "cloud_router" {
     }
   ]
 }
+
+# IP address of the machine that this Terraform operation is running on.
+# This IP is added to "authorized networks" for access to GKE control plane
+data "http" "installation_workstation_ip" {
+  url = "http://ipv4.icanhazip.com"
+}

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -164,35 +164,3 @@ module "cloud_router" {
     }
   ]
 }
-
-# IP address of the machine that this Terraform operation is running on.
-# This IP is added to "authorized networks" for access to GKE control plane
-data "http" "installation_workstation_ip" {
-  url = "http://ipv4.icanhazip.com"
-}
-
-module "distributed_tff_example_firewall_rules" {
-  count = var.distributed_tff_example_deploy_ingress_gateway ? 1 : 0
-
-  source  = "terraform-google-modules/network/google//modules/firewall-rules"
-  version = "7.2.0"
-
-  project_id   = data.google_project.project.project_id
-  network_name = module.fedlearn-vpc.network_name
-
-  ingress_rules = [{
-    name                    = "allow-distributed-tff-example-grpc-ingress"
-    description             = "Allow ingress to the gRPC port for the distributed TensorFlow Federated example"
-    destination_ranges      = [module.fedlearn-vpc.subnets[local.fedlearn_subnet_key].ip_cidr_range, local.fedlearn_pods_ip_range, local.fedlearn_services_ip_range]
-    target_service_accounts = local.list_nodepool_sa_emails
-
-    allow = [{
-      protocol = "tcp"
-      ports    = ["8000"]
-    }]
-
-    log_config = {
-      metadata = "INCLUDE_ALL_METADATA"
-    }
-  }]
-}

--- a/terraform/scripts/generate-copy-acm-tenant-content.sh
+++ b/terraform/scripts/generate-copy-acm-tenant-content.sh
@@ -43,17 +43,14 @@ echo "DISTRIBUTED_TFF_EXAMPLE_DEPLOY: ${DISTRIBUTED_TFF_EXAMPLE_DEPLOY}"
 if [ "${DISTRIBUTED_TFF_EXAMPLE_DEPLOY}" = "true" ]; then
   DISTRIBUTED_TFF_EXAMPLE_PACKAGE_PATH="${7}"
   IS_TFF_COORDINATOR="${8}"
-
   TFF_WORKER_EMNIST_PARTITION_FILE_NAME="${9:-"not-needed"}"
-
   TFF_WORKER_1_ADDRESS="${10:-"not-needed"}"
   TFF_WORKER_2_ADDRESS="${11:-"not-needed"}"
-
   TFF_COORDINATOR_POD_SERVICE_ACCOUNT_NAME="${12}"
-
   TFF_COORDINATOR_NAMESPACE="${13:-"istio-ingress"}"
+  CONFIGURE_WORKER_INGRESS_GATEWAY="${14:-"false"}"
 
-  DISTRIBUTED_TFF_EXAMPLE_CONTAINER_IMAGE_LOCALIZED_ID="${14}"
+  DISTRIBUTED_TFF_EXAMPLE_CONTAINER_IMAGE_LOCALIZED_ID="${15}"
 
   DISTRIBUTED_TFF_EXAMPLE_OUTPUT_DIRECTORY_PATH="${TENANT_CONFIGURATION_DIRECTORY_PATH}/example-tff-image-classification"
 
@@ -72,6 +69,12 @@ if [ "${DISTRIBUTED_TFF_EXAMPLE_DEPLOY}" = "true" ]; then
     echo "This configuration is for a worker. Deleting coordinator-specific configuration."
     rm -fv \
       "${DISTRIBUTED_TFF_EXAMPLE_OUTPUT_DIRECTORY_PATH}/coordinator.yaml"
+
+    if [ "${CONFIGURE_WORKER_INGRESS_GATEWAY}" = "false" ]; then
+      echo "This configuration is for a worker but it doesn't need to be exposed using an ingress gateway. Deleting ingress gateway-specific configuration."
+      rm -fv \
+        "${DISTRIBUTED_TFF_EXAMPLE_OUTPUT_DIRECTORY_PATH}/service-mesh-worker-ingress-gateway.yaml"
+    fi
   else
     echo "This configuration is for a coordinator. Deleting worker-specific configuration."
     rm -fv \

--- a/terraform/tenant-configuration.tf
+++ b/terraform/tenant-configuration.tf
@@ -110,16 +110,6 @@ resource "null_resource" "tenant_configuration" {
   ]
 }
 
-data "external" "blueprint_repository_head_commit_hash" {
-  program = [
-    "git",
-    "log",
-    "--pretty=format:{ \"sha\": \"%H\" }",
-    "-1",
-    "HEAD"
-  ]
-}
-
 resource "null_resource" "build_push_distributed_tff_example_container_image" {
   count = local.deploy_distributed_tff_example_any_tenant ? 1 : 0
 

--- a/terraform/tenant-configuration.tf
+++ b/terraform/tenant-configuration.tf
@@ -88,6 +88,7 @@ resource "null_resource" "tenant_configuration" {
 
     source_contents_hash                                         = local.acm_config_sync_tenant_configuration_package_source_content_hash
     distributed_tff_example_package_source_contents_hash         = each.value.distributed_tff_example_deploy ? local.distributed_tff_example_package_source_content_hash : ""
+    distributed_tff_example_container_image_id                   = each.value.distributed_tff_example_deploy ? local.distributed_tff_example_localized_container_image_id : ""
     distributed_tff_example_container_image_source_contents_hash = each.value.distributed_tff_example_deploy ? local.distributed_tff_example_container_image_source_descriptors_content_hash : ""
   }
 

--- a/terraform/tenant-configuration.tf
+++ b/terraform/tenant-configuration.tf
@@ -158,7 +158,7 @@ resource "null_resource" "copy_mesh_wide_distributed_tff_example_content" {
         "${local.distributed_tff_example_mesh_wide_source_directory_path}" \
         "${local.distributed_tff_example_mesh_wide_destination_directory_path}" \
         "${var.distributed_tff_example_deploy_ingress_gateway}" \
-        "${var.distributed_tff_example_coordinator_namespace == "istio-ingress" ? true : false}" \
+        "${local.distributed_tff_example_are_workers_outside_the_coordinator_mesh}" \
         "${local.distributed_tff_example_is_there_a_coordinator}"
     EOT
     destroy_command     = <<-EOT

--- a/terraform/tenant-configuration.tf
+++ b/terraform/tenant-configuration.tf
@@ -78,6 +78,7 @@ resource "null_resource" "tenant_configuration" {
         "${each.value.distributed_tff_example_worker_2_address}" \
         "${each.value.tenant_apps_kubernetes_service_account_name}" \
         "${var.distributed_tff_example_coordinator_namespace}" \
+        "${!each.value.distributed_tff_example_is_coordinator && var.distributed_tff_example_deploy_ingress_gateway}" \
     EOT
     create_script_hash  = md5(file(local.generate_and_copy_acm_tenant_content_script_path))
     destroy_command     = <<-EOT


### PR DESCRIPTION
This PR does the following:

- Provide the necessary configuration to expose workers running as part of the distributed TensorFlow Federated example using an Ingress Gateway.
- Change the distributed TensorFlow Federated container image ID to use the SHA512 hash of the content of the container image source directory instead of the hash of the latest commit in the blueprint repository to avoid unnecessary updates to the container image repository and the Kubernetes deployments.