### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This blueprint provisions cloud resources on Google Cloud. After the initial pro
 you can extended the infrastructure to [Anthos clusters running on premises or on other public clouds](https://cloud.google.com/anthos/clusters/docs/multi-cloud).
 
 This blueprint is aimed at cloud platform administrator and data scientists that
-aim to provision and configure a secure environment to run potentially untrusted
-workloads in their Google Cloud environment.
+need to provision and configure a secure environment to run potentially
+untrusted workloads in their Google Cloud environment.
 
 ## Getting started
 
@@ -149,7 +149,7 @@ The blueprint configures a dedicated namespace for tenant apps and resources:
   ```
 
   If you don't provide all the necessary inputs, Terraform will exit with an
-  error, and will provide information about the  missing inputs. For example,
+  error, and will provide information about the missing inputs. For example,
   you can create a Terraform variables initialization file and set inputs there.
   For more information about providing these inputs, see
   [Terraform input variables](https://developer.hashicorp.com/terraform/language/values/variables).

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ If this error occurs, try running `terraform apply` again.
 ### Errors when pulling container images
 
 If `istio-ingress` or `istio-egress` pods fail to run because GKE cannot
-download their container images, see
+download their container images and GKE reports `ImagePullBackOff` errors, see
 [Troubleshoot gateways](https://cloud.google.com/service-mesh/docs/gateways#troubleshoot_gateways)
 for details about the potential root cause.
 


### PR DESCRIPTION
- Add information about target personas.
- Add `examples` in the list of directories.
- Add a more explicit definition of `tenant`.
- Add an example of the variables that users need to define.
- Add information about what to look for to check that the process completed.
- Add next steps (ready for production, or examples).
- Move `Errors when pulling container images` to the main README because it's generally relevant.
- Add details about the structure of the distributed TFF example.
- Add expected output, so users can verify they deployed the example correctly.
- Explicitly mention to provision multiple clusters in the related example.
- Move the docker compose example in a dedicated section about dev environment.