### PR TITLE
Wait for ASM to be ready before deploying workloads with Config sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,9 @@ Where `node_name` is the Compute Engine instance name to connect to.
 
 This section describes common issues and troubleshooting steps.
 
-### I/O timeouts during Terraform plan or apply
+### I/O timeouts when Terraform plan or apply
 
-If Terraform reports errors when running `plan` or `apply` because it can't get
+If Terraform reports errors when you run `plan` or `apply` because it can't get
 the status of a resource inside a GKE cluster, and it also reports that it needs
 to update the `cidr_block` of the `master_authorized_networks` block of that
 cluster, it might be that the instance that runs Terraform is not part of any
@@ -212,6 +212,11 @@ terraform apply -target module.gke
 
 Then, you can try running `terraform apply` again, without any resource
 targeting.
+
+### Network address assignment errors when Terraform runs
+
+If Terraform reports `connect: cannot assign requested address` errors when
+you run Terraform, try running the command again.
 
 ### Errors when adding the GKE cluster to the Fleet
 

--- a/README.md
+++ b/README.md
@@ -164,13 +164,15 @@ The blueprint configures a dedicated namespace for tenant apps and resources:
 
 1. Wait for the GKE cluster to be reported as ready in the [GKE Kuberentes clusters dashboard](https://cloud.google.com/kubernetes-engine/docs/concepts/dashboards#kubernetes_clusters).
 
-After the process completes, the GKE cluster is ready to host untrusted workloads.
+### Next steps
+
+After deploying the blueprint completes, the GKE cluster is ready to host untrusted workloads.
 To familiarize with the environment that you provisioned, you can also deploy
 the following examples in the GKE cluster:
 
 - [Distributed TensorFlow Federated training](./examples/federated-learning/tff/distributed-fl-simulation-k8s/README.md)
 
-### Add another tenant
+## Add another tenant
 
 This blueprint dynamically provisions a runtime environment for each tenant you
 configure.
@@ -195,7 +197,7 @@ Where `node_name` is the Compute Engine instance name to connect to.
 
 This section describes common issues and troubleshooting steps.
 
-### I/O timeouts when Terraform plan or apply
+### I/O timeouts when running Terraform plan or apply
 
 If Terraform reports errors when you run `plan` or `apply` because it can't get
 the status of a resource inside a GKE cluster, and it also reports that it needs
@@ -213,7 +215,7 @@ terraform apply -target module.gke
 Then, you can try running `terraform apply` again, without any resource
 targeting.
 
-### Network address assignment errors when Terraform runs
+### Network address assignment errors when running Terraform
 
 If Terraform reports `connect: cannot assign requested address` errors when
 you run Terraform, try running the command again.

--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -42,8 +42,4 @@ module "kubectl_asm_wait_for_controlplanerevision" {
   cluster_location        = module.gke.location
   kubectl_create_command  = "kubectl -n istio-system wait ControlPlaneRevision --all --for condition=Reconciled"
   kubectl_destroy_command = ""
-
-  timeouts {
-    create = "60m"
-  }
 }

--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -39,7 +39,7 @@ module "kubectl_asm_wait_for_controlplanerevision_custom_resource_definition" {
   project_id              = data.google_project.project.project_id
   cluster_name            = module.gke.name
   cluster_location        = module.gke.location
-  kubectl_create_command  = "kubectl wait crd/controlplanerevisions.mesh.cloud.google.com --for condition=established --timeout=60m --all-namespaces && kubectl -n istio-system wait ControlPlaneRevision --all --timeout=60m --for condition=Reconciled"
+  kubectl_create_command  = "kubectl wait crd/controlplanerevisions.mesh.cloud.google.com --for condition=established --timeout=60m --all-namespaces"
   kubectl_destroy_command = ""
 
   depends_on = [

--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -41,7 +41,7 @@ module "kubectl_asm_wait_for_controlplanerevision_custom_resource_definition" {
   project_id              = data.google_project.project.project_id
   cluster_name            = module.gke.name
   cluster_location        = module.gke.location
-  kubectl_create_command  = "while ! kubectl wait crd/controlplanerevisions.mesh.cloud.google.com --for condition=established --timeout=60m --all-namespaces; do sleep 5; done"
+  kubectl_create_command  = "/bin/sh -c 'while ! kubectl wait crd/controlplanerevisions.mesh.cloud.google.com --for condition=established --timeout=60m --all-namespaces; do sleep 5; done'"
   kubectl_destroy_command = ""
 
   module_depends_on = [
@@ -60,7 +60,7 @@ module "kubectl_asm_wait_for_controlplanerevision" {
   project_id              = data.google_project.project.project_id
   cluster_name            = module.gke.name
   cluster_location        = module.gke.location
-  kubectl_create_command  = "while ! kubectl -n istio-system wait ControlPlaneRevision --all --timeout=60m --for condition=Reconciled; do sleep 5; done"
+  kubectl_create_command  = "/bin/sh -c 'while ! kubectl -n istio-system wait ControlPlaneRevision --all --timeout=60m --for condition=Reconciled; do sleep 5; done'"
   kubectl_destroy_command = ""
 
   module_depends_on = [

--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -33,7 +33,8 @@ resource "google_gke_hub_feature_membership" "mesh_feature_membership" {
 
 # Wait for the ControlPlaneRevision custom resource to be ready and
 # wait for the ASM control plane revision to be ready so we can safely deploy resources that depend
-# on ASM mutating webhooks
+# on ASM mutating webhooks.
+# Use a single module for two commands to avoid errors when building the plan
 module "kubectl_asm_wait_for_controlplanerevision" {
   source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
   version = "3.1.2"

--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -41,7 +41,7 @@ module "kubectl_asm_wait_for_controlplanerevision_custom_resource_definition" {
   project_id              = data.google_project.project.project_id
   cluster_name            = module.gke.name
   cluster_location        = module.gke.location
-  kubectl_create_command  = "while ! kubectl wait crd/controlplanerevisions.mesh.cloud.google.com --for condition=established --timeout=60m --all-namespaces ; do sleep 5 done"
+  kubectl_create_command  = "while ! kubectl wait crd/controlplanerevisions.mesh.cloud.google.com --for condition=established --timeout=60m --all-namespaces; do sleep 5; done"
   kubectl_destroy_command = ""
 
   module_depends_on = [
@@ -60,7 +60,7 @@ module "kubectl_asm_wait_for_controlplanerevision" {
   project_id              = data.google_project.project.project_id
   cluster_name            = module.gke.name
   cluster_location        = module.gke.location
-  kubectl_create_command  = "while ! kubectl -n istio-system wait ControlPlaneRevision --all --timeout=60m --for condition=Reconciled ; do sleep 5 done"
+  kubectl_create_command  = "while ! kubectl -n istio-system wait ControlPlaneRevision --all --timeout=60m --for condition=Reconciled; do sleep 5; done"
   kubectl_destroy_command = ""
 
   module_depends_on = [

--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -42,4 +42,8 @@ module "kubectl_asm_wait_for_controlplanerevision" {
   cluster_location        = module.gke.location
   kubectl_create_command  = "kubectl -n istio-system wait ControlPlaneRevision --all --for condition=Reconciled"
   kubectl_destroy_command = ""
+
+  timeouts {
+    create = "60m"
+  }
 }

--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -41,7 +41,7 @@ module "kubectl_asm_wait_for_controlplanerevision_custom_resource_definition" {
   project_id              = data.google_project.project.project_id
   cluster_name            = module.gke.name
   cluster_location        = module.gke.location
-  kubectl_create_command  = "/bin/sh -c 'while ! kubectl wait crd/controlplanerevisions.mesh.cloud.google.com --for condition=established --timeout=60m --all-namespaces; do sleep 5; done'"
+  kubectl_create_command  = "/bin/sh -c 'while ! kubectl wait crd/controlplanerevisions.mesh.cloud.google.com --for condition=established --timeout=60m --all-namespaces; do echo \"crd/controlplanerevisions.mesh.cloud.google.com not yet available, waiting...\"; sleep 5; done'"
   kubectl_destroy_command = ""
 
   module_depends_on = [
@@ -60,7 +60,7 @@ module "kubectl_asm_wait_for_controlplanerevision" {
   project_id              = data.google_project.project.project_id
   cluster_name            = module.gke.name
   cluster_location        = module.gke.location
-  kubectl_create_command  = "/bin/sh -c 'while ! kubectl -n istio-system wait ControlPlaneRevision --all --timeout=60m --for condition=Reconciled; do sleep 5; done'"
+  kubectl_create_command  = "/bin/sh -c 'while ! kubectl -n istio-system wait ControlPlaneRevision --all --timeout=60m --for condition=Reconciled; do echo \"ControlPlaneRevision not yet available, waiting...\"; sleep 5; done'"
   kubectl_destroy_command = ""
 
   module_depends_on = [

--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -31,6 +31,22 @@ resource "google_gke_hub_feature_membership" "mesh_feature_membership" {
   provider = google-beta
 }
 
+# Wait for the ControlPlaneRevision custom resource to be ready
+module "kubectl_asm_wait_for_controlplanerevision_custom_resource_definition" {
+  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
+  version = "3.1.2"
+
+  project_id              = data.google_project.project.project_id
+  cluster_name            = module.gke.name
+  cluster_location        = module.gke.location
+  kubectl_create_command  = "kubectl wait crd/controlplanerevisions.mesh.cloud.google.com --for condition=established --timeout=60m --all-namespaces"
+  kubectl_destroy_command = ""
+
+  depends_on = [
+    google_gke_hub_feature_membership.mesh_feature_membership
+  ]
+}
+
 # Wait for the ASM control plane revision to be ready so we can safely deploy resources that depend
 # on ASM mutating webhooks
 module "kubectl_asm_wait_for_controlplanerevision" {
@@ -40,10 +56,10 @@ module "kubectl_asm_wait_for_controlplanerevision" {
   project_id              = data.google_project.project.project_id
   cluster_name            = module.gke.name
   cluster_location        = module.gke.location
-  kubectl_create_command  = "kubectl -n istio-system wait ControlPlaneRevision --all --for condition=Reconciled"
+  kubectl_create_command  = "kubectl -n istio-system wait ControlPlaneRevision --all --timeout=60m --for condition=Reconciled"
   kubectl_destroy_command = ""
 
   depends_on = [
-    google_gke_hub_feature_membership.mesh_feature_membership
+    module.kubectl_asm_wait_for_controlplanerevision_custom_resource_definition.wait
   ]
 }

--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -42,4 +42,8 @@ module "kubectl_asm_wait_for_controlplanerevision" {
   cluster_location        = module.gke.location
   kubectl_create_command  = "kubectl -n istio-system wait ControlPlaneRevision --all --for condition=Reconciled"
   kubectl_destroy_command = ""
+
+  depends_on = [
+    google_gke_hub_feature_membership.mesh_feature_membership
+  ]
 }

--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -31,7 +31,9 @@ resource "google_gke_hub_feature_membership" "mesh_feature_membership" {
   provider = google-beta
 }
 
-# Wait for the ControlPlaneRevision custom resource to be ready
+# Wait for the ControlPlaneRevision custom resource to be ready.
+# Add an explicit "retry until the resource is created" until
+# https://github.com/kubernetes/kubernetes/issues/83242 is implemented.
 module "kubectl_asm_wait_for_controlplanerevision_custom_resource_definition" {
   source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
   version = "3.1.2"
@@ -48,7 +50,9 @@ module "kubectl_asm_wait_for_controlplanerevision_custom_resource_definition" {
 }
 
 # Wait for the ASM control plane revision to be ready so we can safely deploy resources that depend
-# on ASM mutating webhooks
+# on ASM mutating webhooks.
+# Add an explicit "retry until the resource is created" until
+# https://github.com/kubernetes/kubernetes/issues/83242 is implemented.
 module "kubectl_asm_wait_for_controlplanerevision" {
   source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
   version = "3.1.2"

--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -30,3 +30,16 @@ resource "google_gke_hub_feature_membership" "mesh_feature_membership" {
   }
   provider = google-beta
 }
+
+# Wait for the ASM control plane revision to be ready so we can safely deploy resources that depend
+# on ASM mutating webhooks
+module "kubectl_asm_wait_for_controlplanerevision" {
+  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
+  version = "3.1.2"
+
+  project_id              = data.google_project.project.project_id
+  cluster_name            = module.gke.name
+  cluster_location        = module.gke.location
+  kubectl_create_command  = "kubectl -n istio-system wait ControlPlaneRevision --all --for condition=Reconciled"
+  kubectl_destroy_command = ""
+}

--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -42,7 +42,7 @@ module "kubectl_asm_wait_for_controlplanerevision_custom_resource_definition" {
   kubectl_create_command  = "kubectl wait crd/controlplanerevisions.mesh.cloud.google.com --for condition=established --timeout=60m --all-namespaces"
   kubectl_destroy_command = ""
 
-  depends_on = [
+  module_depends_on = [
     google_gke_hub_feature_membership.mesh_feature_membership
   ]
 }
@@ -59,7 +59,7 @@ module "kubectl_asm_wait_for_controlplanerevision" {
   kubectl_create_command  = "kubectl -n istio-system wait ControlPlaneRevision --all --timeout=60m --for condition=Reconciled"
   kubectl_destroy_command = ""
 
-  depends_on = [
+  module_depends_on = [
     module.kubectl_asm_wait_for_controlplanerevision_custom_resource_definition.wait
   ]
 }

--- a/terraform/asm.tf
+++ b/terraform/asm.tf
@@ -39,7 +39,7 @@ module "kubectl_asm_wait_for_controlplanerevision_custom_resource_definition" {
   project_id              = data.google_project.project.project_id
   cluster_name            = module.gke.name
   cluster_location        = module.gke.location
-  kubectl_create_command  = "kubectl wait crd/controlplanerevisions.mesh.cloud.google.com --for condition=established --timeout=60m --all-namespaces"
+  kubectl_create_command  = "while ! kubectl wait crd/controlplanerevisions.mesh.cloud.google.com --for condition=established --timeout=60m --all-namespaces ; do sleep 5 done"
   kubectl_destroy_command = ""
 
   module_depends_on = [
@@ -56,7 +56,7 @@ module "kubectl_asm_wait_for_controlplanerevision" {
   project_id              = data.google_project.project.project_id
   cluster_name            = module.gke.name
   cluster_location        = module.gke.location
-  kubectl_create_command  = "kubectl -n istio-system wait ControlPlaneRevision --all --timeout=60m --for condition=Reconciled"
+  kubectl_create_command  = "while ! kubectl -n istio-system wait ControlPlaneRevision --all --timeout=60m --for condition=Reconciled ; do sleep 5 done"
   kubectl_destroy_command = ""
 
   module_depends_on = [

--- a/terraform/scripts/commit-repository-changes.sh
+++ b/terraform/scripts/commit-repository-changes.sh
@@ -23,8 +23,9 @@ REPOSITORY_BRANCH="${2}"
 if [ -n "$(git -C "${REPOSITORY_DIRECTORY_PATH}" status --porcelain=v1)" ]; then
   git -C "${REPOSITORY_DIRECTORY_PATH}" add .
   git -C "${REPOSITORY_DIRECTORY_PATH}" commit -m "Config update: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-
-  git -C "${REPOSITORY_DIRECTORY_PATH}" push -u origin "${REPOSITORY_BRANCH}"
 else
   echo "There are no changes to commit."
 fi
+
+# Push in any case
+git -C "${REPOSITORY_DIRECTORY_PATH}" push -u origin "${REPOSITORY_BRANCH}"

--- a/terraform/scripts/init-acm-repository.sh
+++ b/terraform/scripts/init-acm-repository.sh
@@ -21,10 +21,11 @@ ACM_REPOSITORY_PATH="${1}"
 ACM_REPOSITORY_URL="${2}"
 ACM_BRANCH="${3}"
 
-if [ -e "${ACM_REPOSITORY_PATH}" ]; then
-  echo "${ACM_REPOSITORY_PATH} already exists. Skipping creation."
+mkdir -vp "${ACM_REPOSITORY_PATH}"
+
+if [ -e "${ACM_REPOSITORY_PATH}/.git" ]; then
+  echo "${ACM_REPOSITORY_PATH} already exists and is already initialized. Skipping creation."
 else
-  mkdir -vp "${ACM_REPOSITORY_PATH}"
   git clone "${ACM_REPOSITORY_URL}" "${ACM_REPOSITORY_PATH}"
 fi
 

--- a/terraform/tenant-configuration.tf
+++ b/terraform/tenant-configuration.tf
@@ -203,7 +203,7 @@ resource "null_resource" "commit_acm_config_sync_configuration" {
   }
 
   depends_on = [
-    # Wait for ASM to be ready because we rely on ASM injection to be ready
+    # Wait for ASM to be ready because we rely on ASM mutating webhooks
     module.kubectl_asm_wait_for_controlplanerevision,
 
     null_resource.copy_mesh_wide_distributed_tff_example_content,

--- a/terraform/tenant-configuration.tf
+++ b/terraform/tenant-configuration.tf
@@ -203,6 +203,9 @@ resource "null_resource" "commit_acm_config_sync_configuration" {
   }
 
   depends_on = [
+    # Wait for ASM to be ready because we rely on ASM injection to be ready
+    module.kubectl_asm_wait_for_controlplanerevision,
+
     null_resource.copy_mesh_wide_distributed_tff_example_content,
     null_resource.copy_common_acm_content,
     null_resource.init_acm_repository,

--- a/terraform/tenant-configuration.tf
+++ b/terraform/tenant-configuration.tf
@@ -204,7 +204,7 @@ resource "null_resource" "commit_acm_config_sync_configuration" {
 
   depends_on = [
     # Wait for ASM to be ready because we rely on ASM mutating webhooks
-    module.kubectl_asm_wait_for_controlplanerevision,
+    module.kubectl_asm_wait_for_controlplanerevision.wait,
 
     null_resource.copy_mesh_wide_distributed_tff_example_content,
     null_resource.copy_common_acm_content,


### PR DESCRIPTION
Wait for Anthos Service Mesh (ASM) to be ready so that workloads that rely on ASM sidecar injection, such as gateways, don't fail because ASM mutating webhooks didn't have a chance to modify resources before being ready.

Also:

Fix #272 