### PR TITLE
Update README: fix typos and add link to the workloads dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,11 +236,13 @@ If this error occurs, try running `terraform apply` again.
 
 ### Errors when pulling container images
 
-If `istio-ingress` or `istio-egress` pods fail to run because GKE cannot
+If `istio-ingress` or `istio-egress` Pods fail to run because GKE cannot
 download their container images and GKE reports `ImagePullBackOff` errors, see
 [Troubleshoot gateways](https://cloud.google.com/service-mesh/docs/gateways#troubleshoot_gateways)
-for details about the potential root cause.
+for details about the potential root cause. You can inspect the status of these
+Pods in the
+[GKE Workloads Dashboard](https://cloud.google.com/kubernetes-engine/docs/concepts/dashboards#workloads).
 
 If this happens, wait for the cluster to complete the initialiazation, and
-delete the deployment that has this issue. Config Sync will deploy it again with
+delete the Deployment that has this issue. Config Sync will deploy it again with
 the correct container image identifiers.

--- a/examples/federated-learning/tff/distributed-fl-simulation-k8s/README.md
+++ b/examples/federated-learning/tff/distributed-fl-simulation-k8s/README.md
@@ -67,7 +67,7 @@ You can run this example in different runtime environments:
     ```
 
 1. Run `terraform apply`, and wait for Terraform to complete the provisioning process.
-1. Open the [GKE Worklods Dashboard](https://cloud.google.com/kubernetes-engine/docs/concepts/dashboards#workloads)
+1. Open the [GKE Workloads Dashboard](https://cloud.google.com/kubernetes-engine/docs/concepts/dashboards#workloads)
     and wait for the workers Deployments and Services to be ready.
 1. Configure the coordinator by adding the `fltenant3` element to the
     `distributed_tff_example_configuration` map. The other elements of the map
@@ -131,7 +131,7 @@ You can run this example in different runtime environments:
     ```
 
 1. Run `terraform apply`.
-1. Open the [GKE Worklods Dashboard](https://cloud.google.com/kubernetes-engine/docs/concepts/dashboards#workloads)
+1. Open the [GKE Workloads Dashboard](https://cloud.google.com/kubernetes-engine/docs/concepts/dashboards#workloads)
     and wait for the workers Deployments and Services to be ready.
 1. From Cloud Shell, change the working directory to the `terraform` directory that you used to provision
     the resources for the second worker.


### PR DESCRIPTION
- Fix a few typos in the distributed TFF example README.
- Add a link to the GKE workloads dashboard in the main README.