### PR TITLE
Fix coordinator mesh config path for workers outside the mesh

### DIFF
--- a/terraform/scripts/generate-copy-acm-tenant-content.sh
+++ b/terraform/scripts/generate-copy-acm-tenant-content.sh
@@ -86,7 +86,7 @@ if [ "${DISTRIBUTED_TFF_EXAMPLE_DEPLOY}" = "true" ]; then
       "${DISTRIBUTED_TFF_EXAMPLE_OUTPUT_DIRECTORY_PATH}/service-mesh-worker-ingress-gateway.yaml"
 
     if [ "${ARE_WORKERS_OUTSIDE_MESH}" = "false" ]; then
-      rm -v "${DISTRIBUTED_TFF_EXAMPLE_OUTPUT_DIRECTORY_PATH}/service-mesh-workers-outside-mesh.yaml"
+      rm -v "${DISTRIBUTED_TFF_EXAMPLE_OUTPUT_DIRECTORY_PATH}/service-mesh-coordinator-workers-outside-mesh.yaml"
     fi
   fi
 


### PR DESCRIPTION
Fix the path of the distributed TFF example configuration file for the coordinator when workers are outside the mesh (i.e. in another GKE cluster).