### PR TITLE
Automate super-linter dependency updates

### DIFF
--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -51,5 +51,6 @@ jobs:
           || steps.metadata.outputs.dependency-names == 'hashicorp/external'
           || steps.metadata.outputs.dependency-names == 'hashicorp/google-beta'
           || steps.metadata.outputs.dependency-names == 'hashicorp/google'
+          || steps.metadata.outputs.dependency-names == 'super-linter/super-linter'
         run: gh pr merge --auto --squash --delete-branch "${PR_URL}"
 ...


### PR DESCRIPTION
Add `super-linter/super-linter` to the set of automatically managed dependencies.